### PR TITLE
Changed return type to include attributes where appropriate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path-clean = "1.0.1"
 rand = "0.8.5"
 thiserror = "1.0.58"
 url = "2.5.0"
-wit-bindgen-rt = { version = "0.24.0", features = ["bitflags"] }
+wit-bindgen-rt = { version = "0.25.0", features = ["bitflags"] }
 xdr-codec = "0.4.4"
 
 [package.metadata.component]

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -4055,6 +4055,8 @@ pub mod exports {
                 static __FORCE_SECTION_REF: fn() =
                     super::super::super::super::__link_custom_section_describing_imports;
                 use super::super::super::super::_rt;
+                pub type Fh = _rt::Vec<u8>;
+                pub type Bytes = _rt::Vec<u8>;
                 #[repr(C)]
                 #[derive(Clone, Copy)]
                 pub struct Time {
@@ -4105,6 +4107,19 @@ pub mod exports {
                             .finish()
                     }
                 }
+                #[derive(Clone)]
+                pub struct ObjRes {
+                    pub obj: Fh,
+                    pub attr: Option<Attr>,
+                }
+                impl ::core::fmt::Debug for ObjRes {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        f.debug_struct("ObjRes")
+                            .field("obj", &self.obj)
+                            .field("attr", &self.attr)
+                            .finish()
+                    }
+                }
                 #[repr(C)]
                 #[derive(Clone, Copy)]
                 pub struct PathConf {
@@ -4150,7 +4165,7 @@ pub mod exports {
                     pub file_name: _rt::String,
                     pub cookie: u64,
                     pub attr: Option<Attr>,
-                    pub handle: _rt::Vec<u8>,
+                    pub handle: Fh,
                 }
                 impl ::core::fmt::Debug for ReaddirplusEntry {
                     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -4767,34 +4782,91 @@ pub mod exports {
                     match result2 {
                         Ok(e) => {
                             *ptr3.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec4 = (e).into_boxed_slice();
-                            let ptr4 = vec4.as_ptr().cast::<u8>();
-                            let len4 = vec4.len();
-                            ::core::mem::forget(vec4);
-                            *ptr3.add(8).cast::<usize>() = len4;
-                            *ptr3.add(4).cast::<*mut u8>() = ptr4.cast_mut();
+                            let ObjRes {
+                                obj: obj4,
+                                attr: attr4,
+                            } = e;
+                            let vec5 = (obj4).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr3.add(12).cast::<usize>() = len5;
+                            *ptr3.add(8).cast::<*mut u8>() = ptr5.cast_mut();
+                            match attr4 {
+                                Some(e) => {
+                                    *ptr3.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type6,
+                                        file_mode: file_mode6,
+                                        nlink: nlink6,
+                                        uid: uid6,
+                                        gid: gid6,
+                                        filesize: filesize6,
+                                        used: used6,
+                                        spec_data: spec_data6,
+                                        fsid: fsid6,
+                                        fileid: fileid6,
+                                        atime: atime6,
+                                        mtime: mtime6,
+                                        ctime: ctime6,
+                                    } = e;
+                                    *ptr3.add(24).cast::<i32>() = _rt::as_i32(attr_type6);
+                                    *ptr3.add(28).cast::<i32>() = _rt::as_i32(file_mode6);
+                                    *ptr3.add(32).cast::<i32>() = _rt::as_i32(nlink6);
+                                    *ptr3.add(36).cast::<i32>() = _rt::as_i32(uid6);
+                                    *ptr3.add(40).cast::<i32>() = _rt::as_i32(gid6);
+                                    *ptr3.add(48).cast::<i64>() = _rt::as_i64(filesize6);
+                                    *ptr3.add(56).cast::<i64>() = _rt::as_i64(used6);
+                                    let (t7_0, t7_1) = spec_data6;
+                                    *ptr3.add(64).cast::<i32>() = _rt::as_i32(t7_0);
+                                    *ptr3.add(68).cast::<i32>() = _rt::as_i32(t7_1);
+                                    *ptr3.add(72).cast::<i64>() = _rt::as_i64(fsid6);
+                                    *ptr3.add(80).cast::<i64>() = _rt::as_i64(fileid6);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = atime6;
+                                    *ptr3.add(88).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr3.add(92).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = mtime6;
+                                    *ptr3.add(96).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr3.add(100).cast::<i32>() = _rt::as_i32(nseconds9);
+                                    let Time {
+                                        seconds: seconds10,
+                                        nseconds: nseconds10,
+                                    } = ctime6;
+                                    *ptr3.add(104).cast::<i32>() = _rt::as_i32(seconds10);
+                                    *ptr3.add(108).cast::<i32>() = _rt::as_i32(nseconds10);
+                                }
+                                None => {
+                                    *ptr3.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr3.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code5,
-                                message: message5,
+                                nfs_error_code: nfs_error_code11,
+                                message: message11,
                             } = e;
-                            match nfs_error_code5 {
+                            match nfs_error_code11 {
                                 Some(e) => {
-                                    *ptr3.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr3.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr3.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr3.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr3.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr3.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec6 = (message5.into_bytes()).into_boxed_slice();
-                            let ptr6 = vec6.as_ptr().cast::<u8>();
-                            let len6 = vec6.len();
-                            ::core::mem::forget(vec6);
-                            *ptr3.add(16).cast::<usize>() = len6;
-                            *ptr3.add(12).cast::<*mut u8>() = ptr6.cast_mut();
+                            let vec12 = (message11.into_bytes()).into_boxed_slice();
+                            let ptr12 = vec12.as_ptr().cast::<u8>();
+                            let len12 = vec12.len();
+                            ::core::mem::forget(vec12);
+                            *ptr3.add(20).cast::<usize>() = len12;
+                            *ptr3.add(16).cast::<*mut u8>() = ptr12.cast_mut();
                         }
                     };
                     ptr3
@@ -4807,15 +4879,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -4841,34 +4913,91 @@ pub mod exports {
                     match result1 {
                         Ok(e) => {
                             *ptr2.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec3 = (e).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr2.add(8).cast::<usize>() = len3;
-                            *ptr2.add(4).cast::<*mut u8>() = ptr3.cast_mut();
+                            let ObjRes {
+                                obj: obj3,
+                                attr: attr3,
+                            } = e;
+                            let vec4 = (obj3).into_boxed_slice();
+                            let ptr4 = vec4.as_ptr().cast::<u8>();
+                            let len4 = vec4.len();
+                            ::core::mem::forget(vec4);
+                            *ptr2.add(12).cast::<usize>() = len4;
+                            *ptr2.add(8).cast::<*mut u8>() = ptr4.cast_mut();
+                            match attr3 {
+                                Some(e) => {
+                                    *ptr2.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type5,
+                                        file_mode: file_mode5,
+                                        nlink: nlink5,
+                                        uid: uid5,
+                                        gid: gid5,
+                                        filesize: filesize5,
+                                        used: used5,
+                                        spec_data: spec_data5,
+                                        fsid: fsid5,
+                                        fileid: fileid5,
+                                        atime: atime5,
+                                        mtime: mtime5,
+                                        ctime: ctime5,
+                                    } = e;
+                                    *ptr2.add(24).cast::<i32>() = _rt::as_i32(attr_type5);
+                                    *ptr2.add(28).cast::<i32>() = _rt::as_i32(file_mode5);
+                                    *ptr2.add(32).cast::<i32>() = _rt::as_i32(nlink5);
+                                    *ptr2.add(36).cast::<i32>() = _rt::as_i32(uid5);
+                                    *ptr2.add(40).cast::<i32>() = _rt::as_i32(gid5);
+                                    *ptr2.add(48).cast::<i64>() = _rt::as_i64(filesize5);
+                                    *ptr2.add(56).cast::<i64>() = _rt::as_i64(used5);
+                                    let (t6_0, t6_1) = spec_data5;
+                                    *ptr2.add(64).cast::<i32>() = _rt::as_i32(t6_0);
+                                    *ptr2.add(68).cast::<i32>() = _rt::as_i32(t6_1);
+                                    *ptr2.add(72).cast::<i64>() = _rt::as_i64(fsid5);
+                                    *ptr2.add(80).cast::<i64>() = _rt::as_i64(fileid5);
+                                    let Time {
+                                        seconds: seconds7,
+                                        nseconds: nseconds7,
+                                    } = atime5;
+                                    *ptr2.add(88).cast::<i32>() = _rt::as_i32(seconds7);
+                                    *ptr2.add(92).cast::<i32>() = _rt::as_i32(nseconds7);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = mtime5;
+                                    *ptr2.add(96).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr2.add(100).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = ctime5;
+                                    *ptr2.add(104).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr2.add(108).cast::<i32>() = _rt::as_i32(nseconds9);
+                                }
+                                None => {
+                                    *ptr2.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr2.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code4,
-                                message: message4,
+                                nfs_error_code: nfs_error_code10,
+                                message: message10,
                             } = e;
-                            match nfs_error_code4 {
+                            match nfs_error_code10 {
                                 Some(e) => {
-                                    *ptr2.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr2.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr2.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr2.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr2.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr2.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr2.add(16).cast::<usize>() = len5;
-                            *ptr2.add(12).cast::<*mut u8>() = ptr5.cast_mut();
+                            let vec11 = (message10.into_bytes()).into_boxed_slice();
+                            let ptr11 = vec11.as_ptr().cast::<u8>();
+                            let len11 = vec11.len();
+                            ::core::mem::forget(vec11);
+                            *ptr2.add(20).cast::<usize>() = len11;
+                            *ptr2.add(16).cast::<*mut u8>() = ptr11.cast_mut();
                         }
                     };
                     ptr2
@@ -4881,15 +5010,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -5833,34 +5962,91 @@ pub mod exports {
                     match result3 {
                         Ok(e) => {
                             *ptr4.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec5 = (e).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr4.add(8).cast::<usize>() = len5;
-                            *ptr4.add(4).cast::<*mut u8>() = ptr5.cast_mut();
+                            let ObjRes {
+                                obj: obj5,
+                                attr: attr5,
+                            } = e;
+                            let vec6 = (obj5).into_boxed_slice();
+                            let ptr6 = vec6.as_ptr().cast::<u8>();
+                            let len6 = vec6.len();
+                            ::core::mem::forget(vec6);
+                            *ptr4.add(12).cast::<usize>() = len6;
+                            *ptr4.add(8).cast::<*mut u8>() = ptr6.cast_mut();
+                            match attr5 {
+                                Some(e) => {
+                                    *ptr4.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type7,
+                                        file_mode: file_mode7,
+                                        nlink: nlink7,
+                                        uid: uid7,
+                                        gid: gid7,
+                                        filesize: filesize7,
+                                        used: used7,
+                                        spec_data: spec_data7,
+                                        fsid: fsid7,
+                                        fileid: fileid7,
+                                        atime: atime7,
+                                        mtime: mtime7,
+                                        ctime: ctime7,
+                                    } = e;
+                                    *ptr4.add(24).cast::<i32>() = _rt::as_i32(attr_type7);
+                                    *ptr4.add(28).cast::<i32>() = _rt::as_i32(file_mode7);
+                                    *ptr4.add(32).cast::<i32>() = _rt::as_i32(nlink7);
+                                    *ptr4.add(36).cast::<i32>() = _rt::as_i32(uid7);
+                                    *ptr4.add(40).cast::<i32>() = _rt::as_i32(gid7);
+                                    *ptr4.add(48).cast::<i64>() = _rt::as_i64(filesize7);
+                                    *ptr4.add(56).cast::<i64>() = _rt::as_i64(used7);
+                                    let (t8_0, t8_1) = spec_data7;
+                                    *ptr4.add(64).cast::<i32>() = _rt::as_i32(t8_0);
+                                    *ptr4.add(68).cast::<i32>() = _rt::as_i32(t8_1);
+                                    *ptr4.add(72).cast::<i64>() = _rt::as_i64(fsid7);
+                                    *ptr4.add(80).cast::<i64>() = _rt::as_i64(fileid7);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = atime7;
+                                    *ptr4.add(88).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr4.add(92).cast::<i32>() = _rt::as_i32(nseconds9);
+                                    let Time {
+                                        seconds: seconds10,
+                                        nseconds: nseconds10,
+                                    } = mtime7;
+                                    *ptr4.add(96).cast::<i32>() = _rt::as_i32(seconds10);
+                                    *ptr4.add(100).cast::<i32>() = _rt::as_i32(nseconds10);
+                                    let Time {
+                                        seconds: seconds11,
+                                        nseconds: nseconds11,
+                                    } = ctime7;
+                                    *ptr4.add(104).cast::<i32>() = _rt::as_i32(seconds11);
+                                    *ptr4.add(108).cast::<i32>() = _rt::as_i32(nseconds11);
+                                }
+                                None => {
+                                    *ptr4.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr4.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code6,
-                                message: message6,
+                                nfs_error_code: nfs_error_code12,
+                                message: message12,
                             } = e;
-                            match nfs_error_code6 {
+                            match nfs_error_code12 {
                                 Some(e) => {
-                                    *ptr4.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr4.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr4.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr4.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr4.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr4.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec7 = (message6.into_bytes()).into_boxed_slice();
-                            let ptr7 = vec7.as_ptr().cast::<u8>();
-                            let len7 = vec7.len();
-                            ::core::mem::forget(vec7);
-                            *ptr4.add(16).cast::<usize>() = len7;
-                            *ptr4.add(12).cast::<*mut u8>() = ptr7.cast_mut();
+                            let vec13 = (message12.into_bytes()).into_boxed_slice();
+                            let ptr13 = vec13.as_ptr().cast::<u8>();
+                            let len13 = vec13.len();
+                            ::core::mem::forget(vec13);
+                            *ptr4.add(20).cast::<usize>() = len13;
+                            *ptr4.add(16).cast::<*mut u8>() = ptr13.cast_mut();
                         }
                     };
                     ptr4
@@ -5873,15 +6059,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -5910,34 +6096,91 @@ pub mod exports {
                     match result2 {
                         Ok(e) => {
                             *ptr3.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec4 = (e).into_boxed_slice();
-                            let ptr4 = vec4.as_ptr().cast::<u8>();
-                            let len4 = vec4.len();
-                            ::core::mem::forget(vec4);
-                            *ptr3.add(8).cast::<usize>() = len4;
-                            *ptr3.add(4).cast::<*mut u8>() = ptr4.cast_mut();
+                            let ObjRes {
+                                obj: obj4,
+                                attr: attr4,
+                            } = e;
+                            let vec5 = (obj4).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr3.add(12).cast::<usize>() = len5;
+                            *ptr3.add(8).cast::<*mut u8>() = ptr5.cast_mut();
+                            match attr4 {
+                                Some(e) => {
+                                    *ptr3.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type6,
+                                        file_mode: file_mode6,
+                                        nlink: nlink6,
+                                        uid: uid6,
+                                        gid: gid6,
+                                        filesize: filesize6,
+                                        used: used6,
+                                        spec_data: spec_data6,
+                                        fsid: fsid6,
+                                        fileid: fileid6,
+                                        atime: atime6,
+                                        mtime: mtime6,
+                                        ctime: ctime6,
+                                    } = e;
+                                    *ptr3.add(24).cast::<i32>() = _rt::as_i32(attr_type6);
+                                    *ptr3.add(28).cast::<i32>() = _rt::as_i32(file_mode6);
+                                    *ptr3.add(32).cast::<i32>() = _rt::as_i32(nlink6);
+                                    *ptr3.add(36).cast::<i32>() = _rt::as_i32(uid6);
+                                    *ptr3.add(40).cast::<i32>() = _rt::as_i32(gid6);
+                                    *ptr3.add(48).cast::<i64>() = _rt::as_i64(filesize6);
+                                    *ptr3.add(56).cast::<i64>() = _rt::as_i64(used6);
+                                    let (t7_0, t7_1) = spec_data6;
+                                    *ptr3.add(64).cast::<i32>() = _rt::as_i32(t7_0);
+                                    *ptr3.add(68).cast::<i32>() = _rt::as_i32(t7_1);
+                                    *ptr3.add(72).cast::<i64>() = _rt::as_i64(fsid6);
+                                    *ptr3.add(80).cast::<i64>() = _rt::as_i64(fileid6);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = atime6;
+                                    *ptr3.add(88).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr3.add(92).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = mtime6;
+                                    *ptr3.add(96).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr3.add(100).cast::<i32>() = _rt::as_i32(nseconds9);
+                                    let Time {
+                                        seconds: seconds10,
+                                        nseconds: nseconds10,
+                                    } = ctime6;
+                                    *ptr3.add(104).cast::<i32>() = _rt::as_i32(seconds10);
+                                    *ptr3.add(108).cast::<i32>() = _rt::as_i32(nseconds10);
+                                }
+                                None => {
+                                    *ptr3.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr3.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code5,
-                                message: message5,
+                                nfs_error_code: nfs_error_code11,
+                                message: message11,
                             } = e;
-                            match nfs_error_code5 {
+                            match nfs_error_code11 {
                                 Some(e) => {
-                                    *ptr3.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr3.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr3.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr3.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr3.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr3.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec6 = (message5.into_bytes()).into_boxed_slice();
-                            let ptr6 = vec6.as_ptr().cast::<u8>();
-                            let len6 = vec6.len();
-                            ::core::mem::forget(vec6);
-                            *ptr3.add(16).cast::<usize>() = len6;
-                            *ptr3.add(12).cast::<*mut u8>() = ptr6.cast_mut();
+                            let vec12 = (message11.into_bytes()).into_boxed_slice();
+                            let ptr12 = vec12.as_ptr().cast::<u8>();
+                            let len12 = vec12.len();
+                            ::core::mem::forget(vec12);
+                            *ptr3.add(20).cast::<usize>() = len12;
+                            *ptr3.add(16).cast::<*mut u8>() = ptr12.cast_mut();
                         }
                     };
                     ptr3
@@ -5950,15 +6193,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -6125,34 +6368,91 @@ pub mod exports {
                     match result2 {
                         Ok(e) => {
                             *ptr3.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec4 = (e).into_boxed_slice();
-                            let ptr4 = vec4.as_ptr().cast::<u8>();
-                            let len4 = vec4.len();
-                            ::core::mem::forget(vec4);
-                            *ptr3.add(8).cast::<usize>() = len4;
-                            *ptr3.add(4).cast::<*mut u8>() = ptr4.cast_mut();
+                            let ObjRes {
+                                obj: obj4,
+                                attr: attr4,
+                            } = e;
+                            let vec5 = (obj4).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr3.add(12).cast::<usize>() = len5;
+                            *ptr3.add(8).cast::<*mut u8>() = ptr5.cast_mut();
+                            match attr4 {
+                                Some(e) => {
+                                    *ptr3.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type6,
+                                        file_mode: file_mode6,
+                                        nlink: nlink6,
+                                        uid: uid6,
+                                        gid: gid6,
+                                        filesize: filesize6,
+                                        used: used6,
+                                        spec_data: spec_data6,
+                                        fsid: fsid6,
+                                        fileid: fileid6,
+                                        atime: atime6,
+                                        mtime: mtime6,
+                                        ctime: ctime6,
+                                    } = e;
+                                    *ptr3.add(24).cast::<i32>() = _rt::as_i32(attr_type6);
+                                    *ptr3.add(28).cast::<i32>() = _rt::as_i32(file_mode6);
+                                    *ptr3.add(32).cast::<i32>() = _rt::as_i32(nlink6);
+                                    *ptr3.add(36).cast::<i32>() = _rt::as_i32(uid6);
+                                    *ptr3.add(40).cast::<i32>() = _rt::as_i32(gid6);
+                                    *ptr3.add(48).cast::<i64>() = _rt::as_i64(filesize6);
+                                    *ptr3.add(56).cast::<i64>() = _rt::as_i64(used6);
+                                    let (t7_0, t7_1) = spec_data6;
+                                    *ptr3.add(64).cast::<i32>() = _rt::as_i32(t7_0);
+                                    *ptr3.add(68).cast::<i32>() = _rt::as_i32(t7_1);
+                                    *ptr3.add(72).cast::<i64>() = _rt::as_i64(fsid6);
+                                    *ptr3.add(80).cast::<i64>() = _rt::as_i64(fileid6);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = atime6;
+                                    *ptr3.add(88).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr3.add(92).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = mtime6;
+                                    *ptr3.add(96).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr3.add(100).cast::<i32>() = _rt::as_i32(nseconds9);
+                                    let Time {
+                                        seconds: seconds10,
+                                        nseconds: nseconds10,
+                                    } = ctime6;
+                                    *ptr3.add(104).cast::<i32>() = _rt::as_i32(seconds10);
+                                    *ptr3.add(108).cast::<i32>() = _rt::as_i32(nseconds10);
+                                }
+                                None => {
+                                    *ptr3.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr3.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code5,
-                                message: message5,
+                                nfs_error_code: nfs_error_code11,
+                                message: message11,
                             } = e;
-                            match nfs_error_code5 {
+                            match nfs_error_code11 {
                                 Some(e) => {
-                                    *ptr3.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr3.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr3.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr3.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr3.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr3.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec6 = (message5.into_bytes()).into_boxed_slice();
-                            let ptr6 = vec6.as_ptr().cast::<u8>();
-                            let len6 = vec6.len();
-                            ::core::mem::forget(vec6);
-                            *ptr3.add(16).cast::<usize>() = len6;
-                            *ptr3.add(12).cast::<*mut u8>() = ptr6.cast_mut();
+                            let vec12 = (message11.into_bytes()).into_boxed_slice();
+                            let ptr12 = vec12.as_ptr().cast::<u8>();
+                            let len12 = vec12.len();
+                            ::core::mem::forget(vec12);
+                            *ptr3.add(20).cast::<usize>() = len12;
+                            *ptr3.add(16).cast::<*mut u8>() = ptr12.cast_mut();
                         }
                     };
                     ptr3
@@ -6165,15 +6465,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -6197,34 +6497,91 @@ pub mod exports {
                     match result1 {
                         Ok(e) => {
                             *ptr2.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec3 = (e).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr2.add(8).cast::<usize>() = len3;
-                            *ptr2.add(4).cast::<*mut u8>() = ptr3.cast_mut();
+                            let ObjRes {
+                                obj: obj3,
+                                attr: attr3,
+                            } = e;
+                            let vec4 = (obj3).into_boxed_slice();
+                            let ptr4 = vec4.as_ptr().cast::<u8>();
+                            let len4 = vec4.len();
+                            ::core::mem::forget(vec4);
+                            *ptr2.add(12).cast::<usize>() = len4;
+                            *ptr2.add(8).cast::<*mut u8>() = ptr4.cast_mut();
+                            match attr3 {
+                                Some(e) => {
+                                    *ptr2.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type5,
+                                        file_mode: file_mode5,
+                                        nlink: nlink5,
+                                        uid: uid5,
+                                        gid: gid5,
+                                        filesize: filesize5,
+                                        used: used5,
+                                        spec_data: spec_data5,
+                                        fsid: fsid5,
+                                        fileid: fileid5,
+                                        atime: atime5,
+                                        mtime: mtime5,
+                                        ctime: ctime5,
+                                    } = e;
+                                    *ptr2.add(24).cast::<i32>() = _rt::as_i32(attr_type5);
+                                    *ptr2.add(28).cast::<i32>() = _rt::as_i32(file_mode5);
+                                    *ptr2.add(32).cast::<i32>() = _rt::as_i32(nlink5);
+                                    *ptr2.add(36).cast::<i32>() = _rt::as_i32(uid5);
+                                    *ptr2.add(40).cast::<i32>() = _rt::as_i32(gid5);
+                                    *ptr2.add(48).cast::<i64>() = _rt::as_i64(filesize5);
+                                    *ptr2.add(56).cast::<i64>() = _rt::as_i64(used5);
+                                    let (t6_0, t6_1) = spec_data5;
+                                    *ptr2.add(64).cast::<i32>() = _rt::as_i32(t6_0);
+                                    *ptr2.add(68).cast::<i32>() = _rt::as_i32(t6_1);
+                                    *ptr2.add(72).cast::<i64>() = _rt::as_i64(fsid5);
+                                    *ptr2.add(80).cast::<i64>() = _rt::as_i64(fileid5);
+                                    let Time {
+                                        seconds: seconds7,
+                                        nseconds: nseconds7,
+                                    } = atime5;
+                                    *ptr2.add(88).cast::<i32>() = _rt::as_i32(seconds7);
+                                    *ptr2.add(92).cast::<i32>() = _rt::as_i32(nseconds7);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = mtime5;
+                                    *ptr2.add(96).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr2.add(100).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = ctime5;
+                                    *ptr2.add(104).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr2.add(108).cast::<i32>() = _rt::as_i32(nseconds9);
+                                }
+                                None => {
+                                    *ptr2.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr2.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code4,
-                                message: message4,
+                                nfs_error_code: nfs_error_code10,
+                                message: message10,
                             } = e;
-                            match nfs_error_code4 {
+                            match nfs_error_code10 {
                                 Some(e) => {
-                                    *ptr2.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr2.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr2.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr2.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr2.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr2.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr2.add(16).cast::<usize>() = len5;
-                            *ptr2.add(12).cast::<*mut u8>() = ptr5.cast_mut();
+                            let vec11 = (message10.into_bytes()).into_boxed_slice();
+                            let ptr11 = vec11.as_ptr().cast::<u8>();
+                            let len11 = vec11.len();
+                            ::core::mem::forget(vec11);
+                            *ptr2.add(20).cast::<usize>() = len11;
+                            *ptr2.add(16).cast::<*mut u8>() = ptr11.cast_mut();
                         }
                     };
                     ptr2
@@ -6237,15 +6594,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -7402,34 +7759,91 @@ pub mod exports {
                     match result2 {
                         Ok(e) => {
                             *ptr3.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec4 = (e).into_boxed_slice();
-                            let ptr4 = vec4.as_ptr().cast::<u8>();
-                            let len4 = vec4.len();
-                            ::core::mem::forget(vec4);
-                            *ptr3.add(8).cast::<usize>() = len4;
-                            *ptr3.add(4).cast::<*mut u8>() = ptr4.cast_mut();
+                            let ObjRes {
+                                obj: obj4,
+                                attr: attr4,
+                            } = e;
+                            let vec5 = (obj4).into_boxed_slice();
+                            let ptr5 = vec5.as_ptr().cast::<u8>();
+                            let len5 = vec5.len();
+                            ::core::mem::forget(vec5);
+                            *ptr3.add(12).cast::<usize>() = len5;
+                            *ptr3.add(8).cast::<*mut u8>() = ptr5.cast_mut();
+                            match attr4 {
+                                Some(e) => {
+                                    *ptr3.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type6,
+                                        file_mode: file_mode6,
+                                        nlink: nlink6,
+                                        uid: uid6,
+                                        gid: gid6,
+                                        filesize: filesize6,
+                                        used: used6,
+                                        spec_data: spec_data6,
+                                        fsid: fsid6,
+                                        fileid: fileid6,
+                                        atime: atime6,
+                                        mtime: mtime6,
+                                        ctime: ctime6,
+                                    } = e;
+                                    *ptr3.add(24).cast::<i32>() = _rt::as_i32(attr_type6);
+                                    *ptr3.add(28).cast::<i32>() = _rt::as_i32(file_mode6);
+                                    *ptr3.add(32).cast::<i32>() = _rt::as_i32(nlink6);
+                                    *ptr3.add(36).cast::<i32>() = _rt::as_i32(uid6);
+                                    *ptr3.add(40).cast::<i32>() = _rt::as_i32(gid6);
+                                    *ptr3.add(48).cast::<i64>() = _rt::as_i64(filesize6);
+                                    *ptr3.add(56).cast::<i64>() = _rt::as_i64(used6);
+                                    let (t7_0, t7_1) = spec_data6;
+                                    *ptr3.add(64).cast::<i32>() = _rt::as_i32(t7_0);
+                                    *ptr3.add(68).cast::<i32>() = _rt::as_i32(t7_1);
+                                    *ptr3.add(72).cast::<i64>() = _rt::as_i64(fsid6);
+                                    *ptr3.add(80).cast::<i64>() = _rt::as_i64(fileid6);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = atime6;
+                                    *ptr3.add(88).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr3.add(92).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = mtime6;
+                                    *ptr3.add(96).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr3.add(100).cast::<i32>() = _rt::as_i32(nseconds9);
+                                    let Time {
+                                        seconds: seconds10,
+                                        nseconds: nseconds10,
+                                    } = ctime6;
+                                    *ptr3.add(104).cast::<i32>() = _rt::as_i32(seconds10);
+                                    *ptr3.add(108).cast::<i32>() = _rt::as_i32(nseconds10);
+                                }
+                                None => {
+                                    *ptr3.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr3.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code5,
-                                message: message5,
+                                nfs_error_code: nfs_error_code11,
+                                message: message11,
                             } = e;
-                            match nfs_error_code5 {
+                            match nfs_error_code11 {
                                 Some(e) => {
-                                    *ptr3.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr3.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr3.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr3.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr3.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr3.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec6 = (message5.into_bytes()).into_boxed_slice();
-                            let ptr6 = vec6.as_ptr().cast::<u8>();
-                            let len6 = vec6.len();
-                            ::core::mem::forget(vec6);
-                            *ptr3.add(16).cast::<usize>() = len6;
-                            *ptr3.add(12).cast::<*mut u8>() = ptr6.cast_mut();
+                            let vec12 = (message11.into_bytes()).into_boxed_slice();
+                            let ptr12 = vec12.as_ptr().cast::<u8>();
+                            let len12 = vec12.len();
+                            ::core::mem::forget(vec12);
+                            *ptr3.add(20).cast::<usize>() = len12;
+                            *ptr3.add(16).cast::<*mut u8>() = ptr12.cast_mut();
                         }
                     };
                     ptr3
@@ -7442,15 +7856,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -7476,34 +7890,91 @@ pub mod exports {
                     match result1 {
                         Ok(e) => {
                             *ptr2.add(0).cast::<u8>() = (0i32) as u8;
-                            let vec3 = (e).into_boxed_slice();
-                            let ptr3 = vec3.as_ptr().cast::<u8>();
-                            let len3 = vec3.len();
-                            ::core::mem::forget(vec3);
-                            *ptr2.add(8).cast::<usize>() = len3;
-                            *ptr2.add(4).cast::<*mut u8>() = ptr3.cast_mut();
+                            let ObjRes {
+                                obj: obj3,
+                                attr: attr3,
+                            } = e;
+                            let vec4 = (obj3).into_boxed_slice();
+                            let ptr4 = vec4.as_ptr().cast::<u8>();
+                            let len4 = vec4.len();
+                            ::core::mem::forget(vec4);
+                            *ptr2.add(12).cast::<usize>() = len4;
+                            *ptr2.add(8).cast::<*mut u8>() = ptr4.cast_mut();
+                            match attr3 {
+                                Some(e) => {
+                                    *ptr2.add(16).cast::<u8>() = (1i32) as u8;
+                                    let Attr {
+                                        attr_type: attr_type5,
+                                        file_mode: file_mode5,
+                                        nlink: nlink5,
+                                        uid: uid5,
+                                        gid: gid5,
+                                        filesize: filesize5,
+                                        used: used5,
+                                        spec_data: spec_data5,
+                                        fsid: fsid5,
+                                        fileid: fileid5,
+                                        atime: atime5,
+                                        mtime: mtime5,
+                                        ctime: ctime5,
+                                    } = e;
+                                    *ptr2.add(24).cast::<i32>() = _rt::as_i32(attr_type5);
+                                    *ptr2.add(28).cast::<i32>() = _rt::as_i32(file_mode5);
+                                    *ptr2.add(32).cast::<i32>() = _rt::as_i32(nlink5);
+                                    *ptr2.add(36).cast::<i32>() = _rt::as_i32(uid5);
+                                    *ptr2.add(40).cast::<i32>() = _rt::as_i32(gid5);
+                                    *ptr2.add(48).cast::<i64>() = _rt::as_i64(filesize5);
+                                    *ptr2.add(56).cast::<i64>() = _rt::as_i64(used5);
+                                    let (t6_0, t6_1) = spec_data5;
+                                    *ptr2.add(64).cast::<i32>() = _rt::as_i32(t6_0);
+                                    *ptr2.add(68).cast::<i32>() = _rt::as_i32(t6_1);
+                                    *ptr2.add(72).cast::<i64>() = _rt::as_i64(fsid5);
+                                    *ptr2.add(80).cast::<i64>() = _rt::as_i64(fileid5);
+                                    let Time {
+                                        seconds: seconds7,
+                                        nseconds: nseconds7,
+                                    } = atime5;
+                                    *ptr2.add(88).cast::<i32>() = _rt::as_i32(seconds7);
+                                    *ptr2.add(92).cast::<i32>() = _rt::as_i32(nseconds7);
+                                    let Time {
+                                        seconds: seconds8,
+                                        nseconds: nseconds8,
+                                    } = mtime5;
+                                    *ptr2.add(96).cast::<i32>() = _rt::as_i32(seconds8);
+                                    *ptr2.add(100).cast::<i32>() = _rt::as_i32(nseconds8);
+                                    let Time {
+                                        seconds: seconds9,
+                                        nseconds: nseconds9,
+                                    } = ctime5;
+                                    *ptr2.add(104).cast::<i32>() = _rt::as_i32(seconds9);
+                                    *ptr2.add(108).cast::<i32>() = _rt::as_i32(nseconds9);
+                                }
+                                None => {
+                                    *ptr2.add(16).cast::<u8>() = (0i32) as u8;
+                                }
+                            };
                         }
                         Err(e) => {
                             *ptr2.add(0).cast::<u8>() = (1i32) as u8;
                             let Error {
-                                nfs_error_code: nfs_error_code4,
-                                message: message4,
+                                nfs_error_code: nfs_error_code10,
+                                message: message10,
                             } = e;
-                            match nfs_error_code4 {
+                            match nfs_error_code10 {
                                 Some(e) => {
-                                    *ptr2.add(4).cast::<u8>() = (1i32) as u8;
-                                    *ptr2.add(8).cast::<i32>() = _rt::as_i32(e);
+                                    *ptr2.add(8).cast::<u8>() = (1i32) as u8;
+                                    *ptr2.add(12).cast::<i32>() = _rt::as_i32(e);
                                 }
                                 None => {
-                                    *ptr2.add(4).cast::<u8>() = (0i32) as u8;
+                                    *ptr2.add(8).cast::<u8>() = (0i32) as u8;
                                 }
                             };
-                            let vec5 = (message4.into_bytes()).into_boxed_slice();
-                            let ptr5 = vec5.as_ptr().cast::<u8>();
-                            let len5 = vec5.len();
-                            ::core::mem::forget(vec5);
-                            *ptr2.add(16).cast::<usize>() = len5;
-                            *ptr2.add(12).cast::<*mut u8>() = ptr5.cast_mut();
+                            let vec11 = (message10.into_bytes()).into_boxed_slice();
+                            let ptr11 = vec11.as_ptr().cast::<u8>();
+                            let len11 = vec11.len();
+                            ::core::mem::forget(vec11);
+                            *ptr2.add(20).cast::<usize>() = len11;
+                            *ptr2.add(16).cast::<*mut u8>() = ptr11.cast_mut();
                         }
                     };
                     ptr2
@@ -7516,15 +7987,15 @@ pub mod exports {
                     let l0 = i32::from(*arg0.add(0).cast::<u8>());
                     match l0 {
                         0 => {
-                            let l1 = *arg0.add(4).cast::<*mut u8>();
-                            let l2 = *arg0.add(8).cast::<usize>();
+                            let l1 = *arg0.add(8).cast::<*mut u8>();
+                            let l2 = *arg0.add(12).cast::<usize>();
                             let base3 = l1;
                             let len3 = l2;
                             _rt::cabi_dealloc(base3, len3 * 1, 1);
                         }
                         _ => {
-                            let l4 = *arg0.add(12).cast::<*mut u8>();
-                            let l5 = *arg0.add(16).cast::<usize>();
+                            let l4 = *arg0.add(16).cast::<*mut u8>();
+                            let l5 = *arg0.add(20).cast::<usize>();
                             _rt::cabi_dealloc(l4, l5, 1);
                         }
                     }
@@ -8018,15 +8489,10 @@ pub mod exports {
                     }
 
                     fn null_op(&self) -> Result<(), Error>;
-                    fn access(&self, fh: _rt::Vec<u8>, mode: u32) -> Result<u32, Error>;
+                    fn access(&self, fh: Fh, mode: u32) -> Result<u32, Error>;
                     fn access_path(&self, path: _rt::String, mode: u32) -> Result<u32, Error>;
                     fn close(&self, seqid: u32, stateid: u64) -> Result<(), Error>;
-                    fn commit(
-                        &self,
-                        fh: _rt::Vec<u8>,
-                        offset: u64,
-                        count: u32,
-                    ) -> Result<(), Error>;
+                    fn commit(&self, fh: Fh, offset: u64, count: u32) -> Result<(), Error>;
                     fn commit_path(
                         &self,
                         path: _rt::String,
@@ -8035,22 +8501,18 @@ pub mod exports {
                     ) -> Result<(), Error>;
                     fn create(
                         &self,
-                        dir_fh: _rt::Vec<u8>,
+                        dir_fh: Fh,
                         filename: _rt::String,
                         mode: u32,
-                    ) -> Result<_rt::Vec<u8>, Error>;
-                    fn create_path(
-                        &self,
-                        path: _rt::String,
-                        mode: u32,
-                    ) -> Result<_rt::Vec<u8>, Error>;
+                    ) -> Result<ObjRes, Error>;
+                    fn create_path(&self, path: _rt::String, mode: u32) -> Result<ObjRes, Error>;
                     fn delegpurge(&self, clientid: u64) -> Result<(), Error>;
                     fn delegreturn(&self, stateid: u64) -> Result<(), Error>;
-                    fn getattr(&self, fh: _rt::Vec<u8>) -> Result<Attr, Error>;
+                    fn getattr(&self, fh: Fh) -> Result<Attr, Error>;
                     fn getattr_path(&self, path: _rt::String) -> Result<Attr, Error>;
                     fn setattr(
                         &self,
-                        fh: _rt::Vec<u8>,
+                        fh: Fh,
                         guard_ctime: Option<Time>,
                         mode: Option<u32>,
                         uid: Option<u32>,
@@ -8073,8 +8535,8 @@ pub mod exports {
                     fn getfh(&self) -> Result<(), Error>;
                     fn link(
                         &self,
-                        src_fh: _rt::Vec<u8>,
-                        dst_dir_fh: _rt::Vec<u8>,
+                        src_fh: Fh,
+                        dst_dir_fh: Fh,
                         dst_filename: _rt::String,
                     ) -> Result<Attr, Error>;
                     fn link_path(
@@ -8085,92 +8547,60 @@ pub mod exports {
                     fn symlink(
                         &self,
                         src_path: _rt::String,
-                        dst_dir_fh: _rt::Vec<u8>,
+                        dst_dir_fh: Fh,
                         dst_filename: _rt::String,
-                    ) -> Result<_rt::Vec<u8>, Error>;
+                    ) -> Result<ObjRes, Error>;
                     fn symlink_path(
                         &self,
                         src_path: _rt::String,
                         dst_path: _rt::String,
-                    ) -> Result<_rt::Vec<u8>, Error>;
-                    fn readlink(&self, fh: _rt::Vec<u8>) -> Result<_rt::String, Error>;
+                    ) -> Result<ObjRes, Error>;
+                    fn readlink(&self, fh: Fh) -> Result<_rt::String, Error>;
                     fn readlink_path(&self, path: _rt::String) -> Result<_rt::String, Error>;
-                    fn lookup(
-                        &self,
-                        dir_fh: _rt::Vec<u8>,
-                        filename: _rt::String,
-                    ) -> Result<_rt::Vec<u8>, Error>;
-                    fn lookup_path(&self, path: _rt::String) -> Result<_rt::Vec<u8>, Error>;
-                    fn pathconf(&self, fh: _rt::Vec<u8>) -> Result<PathConf, Error>;
+                    fn lookup(&self, dir_fh: Fh, filename: _rt::String) -> Result<ObjRes, Error>;
+                    fn lookup_path(&self, path: _rt::String) -> Result<ObjRes, Error>;
+                    fn pathconf(&self, fh: Fh) -> Result<PathConf, Error>;
                     fn pathconf_path(&self, path: _rt::String) -> Result<PathConf, Error>;
-                    fn read(
-                        &self,
-                        fh: _rt::Vec<u8>,
-                        offset: u64,
-                        count: u32,
-                    ) -> Result<_rt::Vec<u8>, Error>;
+                    fn read(&self, fh: Fh, offset: u64, count: u32) -> Result<Bytes, Error>;
                     fn read_path(
                         &self,
                         path: _rt::String,
                         offset: u64,
                         count: u32,
-                    ) -> Result<_rt::Vec<u8>, Error>;
-                    fn write(
-                        &self,
-                        fh: _rt::Vec<u8>,
-                        offset: u64,
-                        data: _rt::Vec<u8>,
-                    ) -> Result<u32, Error>;
+                    ) -> Result<Bytes, Error>;
+                    fn write(&self, fh: Fh, offset: u64, data: Bytes) -> Result<u32, Error>;
                     fn write_path(
                         &self,
                         path: _rt::String,
                         offset: u64,
-                        data: _rt::Vec<u8>,
+                        data: Bytes,
                     ) -> Result<u32, Error>;
-                    fn readdir(
-                        &self,
-                        dir_fh: _rt::Vec<u8>,
-                    ) -> Result<_rt::Vec<ReaddirEntry>, Error>;
+                    fn readdir(&self, dir_fh: Fh) -> Result<_rt::Vec<ReaddirEntry>, Error>;
                     fn readdir_path(
                         &self,
                         dir_path: _rt::String,
                     ) -> Result<_rt::Vec<ReaddirEntry>, Error>;
-                    fn readdirplus(
-                        &self,
-                        dir_fh: _rt::Vec<u8>,
-                    ) -> Result<_rt::Vec<ReaddirplusEntry>, Error>;
+                    fn readdirplus(&self, dir_fh: Fh) -> Result<_rt::Vec<ReaddirplusEntry>, Error>;
                     fn readdirplus_path(
                         &self,
                         dir_path: _rt::String,
                     ) -> Result<_rt::Vec<ReaddirplusEntry>, Error>;
                     fn mkdir(
                         &self,
-                        dir_fh: _rt::Vec<u8>,
+                        dir_fh: Fh,
                         dirname: _rt::String,
                         mode: u32,
-                    ) -> Result<_rt::Vec<u8>, Error>;
-                    fn mkdir_path(
-                        &self,
-                        path: _rt::String,
-                        mode: u32,
-                    ) -> Result<_rt::Vec<u8>, Error>;
-                    fn remove(
-                        &self,
-                        dir_fh: _rt::Vec<u8>,
-                        filename: _rt::String,
-                    ) -> Result<(), Error>;
+                    ) -> Result<ObjRes, Error>;
+                    fn mkdir_path(&self, path: _rt::String, mode: u32) -> Result<ObjRes, Error>;
+                    fn remove(&self, dir_fh: Fh, filename: _rt::String) -> Result<(), Error>;
                     fn remove_path(&self, path: _rt::String) -> Result<(), Error>;
-                    fn rmdir(
-                        &self,
-                        dir_fh: _rt::Vec<u8>,
-                        dirname: _rt::String,
-                    ) -> Result<(), Error>;
+                    fn rmdir(&self, dir_fh: Fh, dirname: _rt::String) -> Result<(), Error>;
                     fn rmdir_path(&self, path: _rt::String) -> Result<(), Error>;
                     fn rename(
                         &self,
-                        from_dir_fh: _rt::Vec<u8>,
+                        from_dir_fh: Fh,
                         from_filename: _rt::String,
-                        to_dir_fh: _rt::Vec<u8>,
+                        to_dir_fh: Fh,
                         to_filename: _rt::String,
                     ) -> Result<(), Error>;
                     fn rename_path(
@@ -8821,8 +9251,8 @@ pub(crate) use __export_nfs_rs_impl as export;
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.24.0:nfs-rs:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 7703] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x9a;\x01A\x02\x01A\x1f\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 7761] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xd4;\x01A\x02\x01A\x1f\
 \x01B\x0a\x04\0\x08pollable\x03\x01\x01h\0\x01@\x01\x04self\x01\0\x7f\x04\0\x16[\
 method]pollable.ready\x01\x02\x01@\x01\x04self\x01\x01\0\x04\0\x16[method]pollab\
 le.block\x01\x03\x01p\x01\x01py\x01@\x01\x02in\x04\0\x05\x04\0\x04poll\x01\x06\x03\
@@ -8916,69 +9346,70 @@ ocket\x01B\x0c\x02\x03\x02\x01\x06\x04\0\x07network\x03\0\0\x02\x03\x02\x01\x08\
 \0\x0aerror-code\x03\0\x02\x02\x03\x02\x01\x10\x04\0\x11ip-address-family\x03\0\x04\
 \x02\x03\x02\x01\x12\x04\0\x0atcp-socket\x03\0\x06\x01i\x07\x01j\x01\x08\x01\x03\
 \x01@\x01\x0eaddress-family\x05\0\x09\x04\0\x11create-tcp-socket\x01\x0a\x03\x01\
-$wasi:sockets/tcp-create-socket@0.2.0\x05\x13\x01Bs\x01r\x02\x07secondsy\x08nsec\
-ondsy\x04\0\x04time\x03\0\0\x01o\x02yy\x01r\x0d\x09attr-typey\x09file-modey\x05n\
-linky\x03uidy\x03gidy\x08filesizew\x04usedw\x09spec-data\x02\x04fsidw\x06fileidw\
-\x05atime\x01\x05mtime\x01\x05ctime\x01\x04\0\x04attr\x03\0\x03\x01k\x04\x01r\x07\
-\x04attr\x05\x07linkmaxy\x08name-maxy\x08no-trunc\x7f\x10chown-restricted\x7f\x10\
-case-insensitive\x7f\x0fcase-preserving\x7f\x04\0\x09path-conf\x03\0\x06\x01r\x03\
-\x06fileidw\x09file-names\x06cookiew\x04\0\x0dreaddir-entry\x03\0\x08\x01p}\x01r\
-\x05\x06fileidw\x09file-names\x06cookiew\x04attr\x05\x06handle\x0a\x04\0\x11read\
-dirplus-entry\x03\0\x0b\x01kz\x01r\x02\x0enfs-error-code\x0d\x07messages\x04\0\x05\
-error\x03\0\x0e\x04\0\x09nfs-mount\x03\x01\x01h\x10\x01j\0\x01\x0f\x01@\x01\x04s\
-elf\x11\0\x12\x04\0\x19[method]nfs-mount.null-op\x01\x13\x01j\x01y\x01\x0f\x01@\x03\
-\x04self\x11\x02fh\x0a\x04modey\0\x14\x04\0\x18[method]nfs-mount.access\x01\x15\x01\
-@\x03\x04self\x11\x04paths\x04modey\0\x14\x04\0\x1d[method]nfs-mount.access-path\
-\x01\x16\x01@\x03\x04self\x11\x05seqidy\x07stateidw\0\x12\x04\0\x17[method]nfs-m\
-ount.close\x01\x17\x01@\x04\x04self\x11\x02fh\x0a\x06offsetw\x05county\0\x12\x04\
-\0\x18[method]nfs-mount.commit\x01\x18\x01@\x04\x04self\x11\x04paths\x06offsetw\x05\
-county\0\x12\x04\0\x1d[method]nfs-mount.commit-path\x01\x19\x01j\x01\x0a\x01\x0f\
-\x01@\x04\x04self\x11\x06dir-fh\x0a\x08filenames\x04modey\0\x1a\x04\0\x18[method\
-]nfs-mount.create\x01\x1b\x01@\x03\x04self\x11\x04paths\x04modey\0\x1a\x04\0\x1d\
-[method]nfs-mount.create-path\x01\x1c\x01@\x02\x04self\x11\x08clientidw\0\x12\x04\
-\0\x1c[method]nfs-mount.delegpurge\x01\x1d\x01@\x02\x04self\x11\x07stateidw\0\x12\
-\x04\0\x1d[method]nfs-mount.delegreturn\x01\x1e\x01j\x01\x04\x01\x0f\x01@\x02\x04\
-self\x11\x02fh\x0a\0\x1f\x04\0\x19[method]nfs-mount.getattr\x01\x20\x01@\x02\x04\
-self\x11\x04paths\0\x1f\x04\0\x1e[method]nfs-mount.getattr-path\x01!\x01k\x01\x01\
-ky\x01kw\x01@\x09\x04self\x11\x02fh\x0a\x0bguard-ctime\"\x04mode#\x03uid#\x03gid\
-#\x04size$\x05atime\"\x05mtime\"\0\x12\x04\0\x19[method]nfs-mount.setattr\x01%\x01\
-@\x09\x04self\x11\x04paths\x0dspecify-guard\x7f\x04mode#\x03uid#\x03gid#\x04size\
-$\x05atime\"\x05mtime\"\0\x12\x04\0\x1e[method]nfs-mount.setattr-path\x01&\x04\0\
-\x17[method]nfs-mount.getfh\x01\x13\x01@\x04\x04self\x11\x06src-fh\x0a\x0adst-di\
-r-fh\x0a\x0cdst-filenames\0\x1f\x04\0\x16[method]nfs-mount.link\x01'\x01@\x03\x04\
-self\x11\x08src-paths\x08dst-paths\0\x1f\x04\0\x1b[method]nfs-mount.link-path\x01\
-(\x01@\x04\x04self\x11\x08src-paths\x0adst-dir-fh\x0a\x0cdst-filenames\0\x1a\x04\
-\0\x19[method]nfs-mount.symlink\x01)\x01@\x03\x04self\x11\x08src-paths\x08dst-pa\
-ths\0\x1a\x04\0\x1e[method]nfs-mount.symlink-path\x01*\x01j\x01s\x01\x0f\x01@\x02\
-\x04self\x11\x02fh\x0a\0+\x04\0\x1a[method]nfs-mount.readlink\x01,\x01@\x02\x04s\
-elf\x11\x04paths\0+\x04\0\x1f[method]nfs-mount.readlink-path\x01-\x01@\x03\x04se\
-lf\x11\x06dir-fh\x0a\x08filenames\0\x1a\x04\0\x18[method]nfs-mount.lookup\x01.\x01\
-@\x02\x04self\x11\x04paths\0\x1a\x04\0\x1d[method]nfs-mount.lookup-path\x01/\x01\
-j\x01\x07\x01\x0f\x01@\x02\x04self\x11\x02fh\x0a\00\x04\0\x1a[method]nfs-mount.p\
-athconf\x011\x01@\x02\x04self\x11\x04paths\00\x04\0\x1f[method]nfs-mount.pathcon\
-f-path\x012\x01@\x04\x04self\x11\x02fh\x0a\x06offsetw\x05county\0\x1a\x04\0\x16[\
-method]nfs-mount.read\x013\x01@\x04\x04self\x11\x04paths\x06offsetw\x05county\0\x1a\
-\x04\0\x1b[method]nfs-mount.read-path\x014\x01@\x04\x04self\x11\x02fh\x0a\x06off\
-setw\x04data\x0a\0\x14\x04\0\x17[method]nfs-mount.write\x015\x01@\x04\x04self\x11\
-\x04paths\x06offsetw\x04data\x0a\0\x14\x04\0\x1c[method]nfs-mount.write-path\x01\
-6\x01p\x09\x01j\x017\x01\x0f\x01@\x02\x04self\x11\x06dir-fh\x0a\08\x04\0\x19[met\
-hod]nfs-mount.readdir\x019\x01@\x02\x04self\x11\x08dir-paths\08\x04\0\x1e[method\
-]nfs-mount.readdir-path\x01:\x01p\x0c\x01j\x01;\x01\x0f\x01@\x02\x04self\x11\x06\
-dir-fh\x0a\0<\x04\0\x1d[method]nfs-mount.readdirplus\x01=\x01@\x02\x04self\x11\x08\
-dir-paths\0<\x04\0\"[method]nfs-mount.readdirplus-path\x01>\x01@\x04\x04self\x11\
-\x06dir-fh\x0a\x07dirnames\x04modey\0\x1a\x04\0\x17[method]nfs-mount.mkdir\x01?\x04\
-\0\x1c[method]nfs-mount.mkdir-path\x01\x1c\x01@\x03\x04self\x11\x06dir-fh\x0a\x08\
-filenames\0\x12\x04\0\x18[method]nfs-mount.remove\x01@\x01@\x02\x04self\x11\x04p\
-aths\0\x12\x04\0\x1d[method]nfs-mount.remove-path\x01A\x01@\x03\x04self\x11\x06d\
-ir-fh\x0a\x07dirnames\0\x12\x04\0\x17[method]nfs-mount.rmdir\x01B\x04\0\x1c[meth\
-od]nfs-mount.rmdir-path\x01A\x01@\x05\x04self\x11\x0bfrom-dir-fh\x0a\x0dfrom-fil\
-enames\x09to-dir-fh\x0a\x0bto-filenames\0\x12\x04\0\x18[method]nfs-mount.rename\x01\
-C\x01@\x03\x04self\x11\x09from-paths\x07to-paths\0\x12\x04\0\x1d[method]nfs-moun\
-t.rename-path\x01D\x04\0\x18[method]nfs-mount.umount\x01\x13\x01i\x10\x01j\x01\xc5\
-\0\x01\x0f\x01@\x01\x03urls\0\xc6\0\x04\0\x13parse-url-and-mount\x01G\x04\x01\x14\
-component:nfs-rs/nfs\x05\x14\x04\x01\x17component:nfs-rs/nfs-rs\x04\0\x0b\x0c\x01\
-\0\x06nfs-rs\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x07\
-0.202.0\x10wit-bindgen-rust\x060.24.0";
+$wasi:sockets/tcp-create-socket@0.2.0\x05\x13\x01By\x01p}\x04\0\x02fh\x03\0\0\x01\
+p}\x04\0\x05bytes\x03\0\x02\x01r\x02\x07secondsy\x08nsecondsy\x04\0\x04time\x03\0\
+\x04\x01o\x02yy\x01r\x0d\x09attr-typey\x09file-modey\x05nlinky\x03uidy\x03gidy\x08\
+filesizew\x04usedw\x09spec-data\x06\x04fsidw\x06fileidw\x05atime\x05\x05mtime\x05\
+\x05ctime\x05\x04\0\x04attr\x03\0\x07\x01k\x08\x01r\x02\x03obj\x01\x04attr\x09\x04\
+\0\x07obj-res\x03\0\x0a\x01r\x07\x04attr\x09\x07linkmaxy\x08name-maxy\x08no-trun\
+c\x7f\x10chown-restricted\x7f\x10case-insensitive\x7f\x0fcase-preserving\x7f\x04\
+\0\x09path-conf\x03\0\x0c\x01r\x03\x06fileidw\x09file-names\x06cookiew\x04\0\x0d\
+readdir-entry\x03\0\x0e\x01r\x05\x06fileidw\x09file-names\x06cookiew\x04attr\x09\
+\x06handle\x01\x04\0\x11readdirplus-entry\x03\0\x10\x01kz\x01r\x02\x0enfs-error-\
+code\x12\x07messages\x04\0\x05error\x03\0\x13\x04\0\x09nfs-mount\x03\x01\x01h\x15\
+\x01j\0\x01\x14\x01@\x01\x04self\x16\0\x17\x04\0\x19[method]nfs-mount.null-op\x01\
+\x18\x01j\x01y\x01\x14\x01@\x03\x04self\x16\x02fh\x01\x04modey\0\x19\x04\0\x18[m\
+ethod]nfs-mount.access\x01\x1a\x01@\x03\x04self\x16\x04paths\x04modey\0\x19\x04\0\
+\x1d[method]nfs-mount.access-path\x01\x1b\x01@\x03\x04self\x16\x05seqidy\x07stat\
+eidw\0\x17\x04\0\x17[method]nfs-mount.close\x01\x1c\x01@\x04\x04self\x16\x02fh\x01\
+\x06offsetw\x05county\0\x17\x04\0\x18[method]nfs-mount.commit\x01\x1d\x01@\x04\x04\
+self\x16\x04paths\x06offsetw\x05county\0\x17\x04\0\x1d[method]nfs-mount.commit-p\
+ath\x01\x1e\x01j\x01\x0b\x01\x14\x01@\x04\x04self\x16\x06dir-fh\x01\x08filenames\
+\x04modey\0\x1f\x04\0\x18[method]nfs-mount.create\x01\x20\x01@\x03\x04self\x16\x04\
+paths\x04modey\0\x1f\x04\0\x1d[method]nfs-mount.create-path\x01!\x01@\x02\x04sel\
+f\x16\x08clientidw\0\x17\x04\0\x1c[method]nfs-mount.delegpurge\x01\"\x01@\x02\x04\
+self\x16\x07stateidw\0\x17\x04\0\x1d[method]nfs-mount.delegreturn\x01#\x01j\x01\x08\
+\x01\x14\x01@\x02\x04self\x16\x02fh\x01\0$\x04\0\x19[method]nfs-mount.getattr\x01\
+%\x01@\x02\x04self\x16\x04paths\0$\x04\0\x1e[method]nfs-mount.getattr-path\x01&\x01\
+k\x05\x01ky\x01kw\x01@\x09\x04self\x16\x02fh\x01\x0bguard-ctime'\x04mode(\x03uid\
+(\x03gid(\x04size)\x05atime'\x05mtime'\0\x17\x04\0\x19[method]nfs-mount.setattr\x01\
+*\x01@\x09\x04self\x16\x04paths\x0dspecify-guard\x7f\x04mode(\x03uid(\x03gid(\x04\
+size)\x05atime'\x05mtime'\0\x17\x04\0\x1e[method]nfs-mount.setattr-path\x01+\x04\
+\0\x17[method]nfs-mount.getfh\x01\x18\x01@\x04\x04self\x16\x06src-fh\x01\x0adst-\
+dir-fh\x01\x0cdst-filenames\0$\x04\0\x16[method]nfs-mount.link\x01,\x01@\x03\x04\
+self\x16\x08src-paths\x08dst-paths\0$\x04\0\x1b[method]nfs-mount.link-path\x01-\x01\
+@\x04\x04self\x16\x08src-paths\x0adst-dir-fh\x01\x0cdst-filenames\0\x1f\x04\0\x19\
+[method]nfs-mount.symlink\x01.\x01@\x03\x04self\x16\x08src-paths\x08dst-paths\0\x1f\
+\x04\0\x1e[method]nfs-mount.symlink-path\x01/\x01j\x01s\x01\x14\x01@\x02\x04self\
+\x16\x02fh\x01\00\x04\0\x1a[method]nfs-mount.readlink\x011\x01@\x02\x04self\x16\x04\
+paths\00\x04\0\x1f[method]nfs-mount.readlink-path\x012\x01@\x03\x04self\x16\x06d\
+ir-fh\x01\x08filenames\0\x1f\x04\0\x18[method]nfs-mount.lookup\x013\x01@\x02\x04\
+self\x16\x04paths\0\x1f\x04\0\x1d[method]nfs-mount.lookup-path\x014\x01j\x01\x0d\
+\x01\x14\x01@\x02\x04self\x16\x02fh\x01\05\x04\0\x1a[method]nfs-mount.pathconf\x01\
+6\x01@\x02\x04self\x16\x04paths\05\x04\0\x1f[method]nfs-mount.pathconf-path\x017\
+\x01j\x01\x03\x01\x14\x01@\x04\x04self\x16\x02fh\x01\x06offsetw\x05county\08\x04\
+\0\x16[method]nfs-mount.read\x019\x01@\x04\x04self\x16\x04paths\x06offsetw\x05co\
+unty\08\x04\0\x1b[method]nfs-mount.read-path\x01:\x01@\x04\x04self\x16\x02fh\x01\
+\x06offsetw\x04data\x03\0\x19\x04\0\x17[method]nfs-mount.write\x01;\x01@\x04\x04\
+self\x16\x04paths\x06offsetw\x04data\x03\0\x19\x04\0\x1c[method]nfs-mount.write-\
+path\x01<\x01p\x0f\x01j\x01=\x01\x14\x01@\x02\x04self\x16\x06dir-fh\x01\0>\x04\0\
+\x19[method]nfs-mount.readdir\x01?\x01@\x02\x04self\x16\x08dir-paths\0>\x04\0\x1e\
+[method]nfs-mount.readdir-path\x01@\x01p\x11\x01j\x01\xc1\0\x01\x14\x01@\x02\x04\
+self\x16\x06dir-fh\x01\0\xc2\0\x04\0\x1d[method]nfs-mount.readdirplus\x01C\x01@\x02\
+\x04self\x16\x08dir-paths\0\xc2\0\x04\0\"[method]nfs-mount.readdirplus-path\x01D\
+\x01@\x04\x04self\x16\x06dir-fh\x01\x07dirnames\x04modey\0\x1f\x04\0\x17[method]\
+nfs-mount.mkdir\x01E\x04\0\x1c[method]nfs-mount.mkdir-path\x01!\x01@\x03\x04self\
+\x16\x06dir-fh\x01\x08filenames\0\x17\x04\0\x18[method]nfs-mount.remove\x01F\x01\
+@\x02\x04self\x16\x04paths\0\x17\x04\0\x1d[method]nfs-mount.remove-path\x01G\x01\
+@\x03\x04self\x16\x06dir-fh\x01\x07dirnames\0\x17\x04\0\x17[method]nfs-mount.rmd\
+ir\x01H\x04\0\x1c[method]nfs-mount.rmdir-path\x01G\x01@\x05\x04self\x16\x0bfrom-\
+dir-fh\x01\x0dfrom-filenames\x09to-dir-fh\x01\x0bto-filenames\0\x17\x04\0\x18[me\
+thod]nfs-mount.rename\x01I\x01@\x03\x04self\x16\x09from-paths\x07to-paths\0\x17\x04\
+\0\x1d[method]nfs-mount.rename-path\x01J\x04\0\x18[method]nfs-mount.umount\x01\x18\
+\x01i\x15\x01j\x01\xcb\0\x01\x14\x01@\x01\x03urls\0\xcc\0\x04\0\x13parse-url-and\
+-mount\x01M\x04\x01\x14component:nfs-rs/nfs\x05\x14\x04\x01\x17component:nfs-rs/\
+nfs-rs\x04\0\x0b\x0c\x01\0\x06nfs-rs\x03\0\0\0G\x09producers\x01\x0cprocessed-by\
+\x02\x0dwit-component\x070.202.0\x10wit-bindgen-rust\x060.24.0";
 
 #[inline(never)]
 #[doc(hidden)]

--- a/src/component.rs
+++ b/src/component.rs
@@ -4,6 +4,7 @@ use crate::{
     Error,
     Mount,
     Attr,
+    ObjRes,
     Pathconf,
     ReaddirEntry,
     ReaddirplusEntry,
@@ -15,8 +16,11 @@ use crate::bindings::exports::component::nfs_rs::nfs::{
     Error as WitError,
     GuestNfsMount as WitMount,
     NfsMount as WitNFSMount,
+    Fh as WitFH,
+    Bytes as WitBytes,
     Attr as WitAttr,
     Time as WitTime,
+    ObjRes as WitObjRes,
     PathConf as WitPathconf,
     ReaddirEntry as WitReaddirEntry,
     ReaddirplusEntry as WitReaddirplusEntry,
@@ -60,104 +64,112 @@ fn remove_mount(mnt: u32) {
     mounts.remove(&mnt);
 }
 
-fn from_wit_time(time: WitTime) -> Time {
-    Time{
-        seconds: time.seconds,
-        nseconds: time.nseconds,
-    }
-}
-
-fn into_wit_time(time: Time) -> WitTime {
-    WitTime{
-        seconds: time.seconds,
-        nseconds: time.nseconds,
-    }
-}
-
-fn into_wit_attr(attr: Attr) -> WitAttr {
-    WitAttr{
-        attr_type: attr.type_,
-        file_mode: attr.file_mode,
-        nlink: attr.nlink,
-        uid: attr.uid,
-        gid: attr.gid,
-        filesize: attr.filesize,
-        used: attr.used,
-        spec_data: (attr.spec_data[0], attr.spec_data[1]),
-        fsid: attr.fsid,
-        fileid: attr.fileid,
-        atime: into_wit_time(attr.atime),
-        mtime: into_wit_time(attr.mtime),
-        ctime: into_wit_time(attr.ctime),
-    }
-}
-
-fn into_wit_path_conf(conf: Pathconf) -> WitPathconf {
-    WitPathconf{
-        attr: conf.attr.map(into_wit_attr),
-        linkmax: conf.linkmax,
-        name_max: conf.name_max,
-        no_trunc: conf.no_trunc,
-        chown_restricted: conf.chown_restricted,
-        case_insensitive: conf.case_insensitive,
-        case_preserving: conf.case_preserving,
-    }
-}
-
-fn into_wit_readdir_entries(entries: Vec<ReaddirEntry>) -> Vec<WitReaddirEntry> {
-    let mut ret = Vec::new();
-    for entry in entries {
-        ret.push(into_wit_readdir_entry(entry));
-    }
-    ret
-}
-
-fn into_wit_readdir_entry(entry: ReaddirEntry) -> WitReaddirEntry {
-    WitReaddirEntry{
-        fileid: entry.fileid,
-        file_name: entry.file_name,
-        cookie: entry.cookie,
-    }
-}
-
-fn into_wit_readdirplus_entries(entries: Vec<ReaddirplusEntry>) -> Vec<WitReaddirplusEntry> {
-    let mut ret = Vec::new();
-    for entry in entries {
-        ret.push(into_wit_readdirplus_entry(entry));
-    }
-    ret
-}
-
-fn into_wit_readdirplus_entry(entry: ReaddirplusEntry) -> WitReaddirplusEntry {
-    WitReaddirplusEntry{
-        fileid: entry.fileid,
-        file_name: entry.file_name,
-        cookie: entry.cookie,
-        attr: entry.attr.map(into_wit_attr),
-        handle: entry.handle,
-    }
-}
-
-fn into_wit_err(mut err: Error) -> WitError {
-    if let Some(inner_err) = err.get_mut() {
-        if inner_err.is::<crate::nfs3::ErrorCode>() {
-            let nfs_error_code = inner_err.downcast_mut::<crate::nfs3::ErrorCode>().unwrap();
-            return WitError{
-                nfs_error_code: Some(*nfs_error_code as i32),
-                message: nfs_error_code.to_string(),
-            }
-        }
-        if inner_err.is::<crate::nfs3::MountErrorCode>() {
-            let mount_error_code = inner_err.downcast_mut::<crate::nfs3::MountErrorCode>().unwrap();
-            return WitError{
-                nfs_error_code: Some(*mount_error_code as i32), // XXX: MOUNT error code values match those of NFS error codes but should we really do this?
-                message: mount_error_code.to_string(),
-            }
+impl From<WitTime> for Time {
+    fn from(time: WitTime) -> Self {
+        Self{
+            seconds: time.seconds,
+            nseconds: time.nseconds,
         }
     }
-    WitError{
-        nfs_error_code: None,
-        message: err.to_string(),
+}
+
+impl From<Time> for WitTime {
+    fn from(time: Time) -> Self {
+        Self{
+            seconds: time.seconds,
+            nseconds: time.nseconds,
+        }
+    }
+}
+
+impl From<Attr> for WitAttr {
+    fn from(attr: Attr) -> Self {
+        Self{
+            attr_type: attr.type_,
+            file_mode: attr.file_mode,
+            nlink: attr.nlink,
+            uid: attr.uid,
+            gid: attr.gid,
+            filesize: attr.filesize,
+            used: attr.used,
+            spec_data: (attr.spec_data[0], attr.spec_data[1]),
+            fsid: attr.fsid,
+            fileid: attr.fileid,
+            atime: attr.atime.into(),
+            mtime: attr.mtime.into(),
+            ctime: attr.ctime.into(),
+        }
+    }
+}
+
+impl From<ObjRes> for WitObjRes {
+    fn from(obj: ObjRes) -> Self {
+        Self{
+            obj: obj.fh,
+            attr: obj.attr.map(Into::into),
+        }
+    }
+}
+
+impl From<Pathconf> for WitPathconf {
+    fn from(conf: Pathconf) -> Self {
+        Self{
+            attr: conf.attr.map(Into::into),
+            linkmax: conf.linkmax,
+            name_max: conf.name_max,
+            no_trunc: conf.no_trunc,
+            chown_restricted: conf.chown_restricted,
+            case_insensitive: conf.case_insensitive,
+            case_preserving: conf.case_preserving,
+        }
+    }
+}
+
+impl From<ReaddirEntry> for WitReaddirEntry {
+    fn from(entry: ReaddirEntry) -> Self {
+        Self{
+            fileid: entry.fileid,
+            file_name: entry.file_name,
+            cookie: entry.cookie,
+        }
+    }
+}
+
+impl From<ReaddirplusEntry> for WitReaddirplusEntry {
+    fn from(entry: ReaddirplusEntry) -> Self {
+        Self{
+            fileid: entry.fileid,
+            file_name: entry.file_name,
+            cookie: entry.cookie,
+            attr: entry.attr.map(Into::into),
+            handle: entry.handle,
+        }
+    }
+}
+
+impl Into<WitError> for Error {
+    fn into(self) -> WitError {
+        let mut err = self;
+        if let Some(inner_err) = err.get_mut() {
+            if inner_err.is::<crate::nfs3::ErrorCode>() {
+                let nfs_error_code = inner_err.downcast_mut::<crate::nfs3::ErrorCode>().unwrap();
+                return WitError{
+                    nfs_error_code: Some(*nfs_error_code as i32),
+                    message: nfs_error_code.to_string(),
+                }
+            }
+            if inner_err.is::<crate::nfs3::MountErrorCode>() {
+                let mount_error_code = inner_err.downcast_mut::<crate::nfs3::MountErrorCode>().unwrap();
+                return WitError{
+                    nfs_error_code: Some(*mount_error_code as i32), // XXX: MOUNT error code values match those of NFS error codes but should we really do this?
+                    message: mount_error_code.to_string(),
+                }
+            }
+        }
+        WitError{
+            nfs_error_code: None,
+            message: err.to_string(),
+        }
     }
 }
 
@@ -167,7 +179,7 @@ impl WitNFS for crate::Component {
     fn parse_url_and_mount(url: String) -> Result<WitNFSMount, WitError> {
         let ret = parse_url_and_mount(&url);
         if ret.is_err() {
-            return Err(into_wit_err(ret.unwrap_err()));
+            return Err(ret.unwrap_err().into());
         }
 
         let id = add_mount(ret.unwrap());
@@ -179,80 +191,82 @@ impl WitMount for crate::NfsMount {
     fn null_op(&self) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.null()
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn access(&self, fh: Vec<u8>, mode: u32) -> Result<u32, WitError> {
+    fn access(&self, fh: WitFH, mode: u32) -> Result<u32, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.access(&fh, mode)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn access_path(&self, path: String, mode: u32) -> Result<u32, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.access_path(&path, mode)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn close(&self, seqid: u32, stateid: u64) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.close(seqid, stateid)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn commit(&self, fh: Vec<u8>, offset: u64, count: u32) -> Result<(), WitError> {
+    fn commit(&self, fh: WitFH, offset: u64, count: u32) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.commit(&fh, offset, count)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn commit_path(&self, path: String, offset: u64, count: u32) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.commit_path(&path, offset, count)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn create(&self, dir_fh: Vec<u8>, filename: String, mode: u32) -> Result<Vec<u8>, WitError> {
+    fn create(&self, dir_fh: WitFH, filename: String, mode: u32) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.create(&dir_fh, &filename, mode)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn create_path(&self, path: String, mode: u32) -> Result<Vec<u8>, WitError> {
+    fn create_path(&self, path: String, mode: u32) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.create_path(&path, mode)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     fn delegpurge(&self, clientid: u64) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.delegpurge(clientid)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn delegreturn(&self, stateid: u64) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.delegreturn(stateid)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn getattr(&self, fh: Vec<u8>) -> Result<WitAttr, WitError> {
+    fn getattr(&self, fh: WitFH) -> Result<WitAttr, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.getattr(&fh)
-            .map(into_wit_attr)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     fn getattr_path(&self, path: String) -> Result<WitAttr, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.getattr_path(&path)
-            .map(into_wit_attr)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     fn setattr(
         &self,
-        fh: Vec<u8>,
+        fh: WitFH,
         guard_ctime: Option<WitTime>,
         mode: Option<u32>,
         uid: Option<u32>,
@@ -264,15 +278,15 @@ impl WitMount for crate::NfsMount {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.setattr(
             &fh,
-            guard_ctime.map(from_wit_time),
+            guard_ctime.map(Into::into),
             mode,
             uid,
             gid,
             size,
-            atime.map(from_wit_time),
-            mtime.map(from_wit_time),
+            atime.map(Into::into),
+            mtime.map(Into::into),
         )
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn setattr_path(
@@ -294,180 +308,186 @@ impl WitMount for crate::NfsMount {
             uid,
             gid,
             size,
-            atime.map(from_wit_time),
-            mtime.map(from_wit_time),
+            atime.map(Into::into),
+            mtime.map(Into::into),
         )
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn getfh(&self) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.getfh()
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn link(&self, src_fh: Vec<u8>, dst_dir_fh: Vec<u8>, dst_filename: String) -> Result<WitAttr, WitError> {
+    fn link(&self, src_fh: WitFH, dst_dir_fh: WitFH, dst_filename: String) -> Result<WitAttr, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.link(&src_fh, &dst_dir_fh, &dst_filename)
-            .map(into_wit_attr)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     fn link_path(&self, src_path: String, dst_path: String) -> Result<WitAttr, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.link_path(&src_path, &dst_path)
-            .map(into_wit_attr)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn symlink(&self, src_path: String, dst_dir_fh: Vec<u8>, dst_filename: String) -> Result<Vec<u8>, WitError> {
+    fn symlink(&self, src_path: String, dst_dir_fh: WitFH, dst_filename: String) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.symlink(&src_path, &dst_dir_fh, &dst_filename)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn symlink_path(&self, src_path: String, dst_path: String) -> Result<Vec<u8>, WitError> {
+    fn symlink_path(&self, src_path: String, dst_path: String) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.symlink_path(&src_path, &dst_path)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn readlink(&self, fh: Vec<u8>) -> Result<String, WitError> {
+    fn readlink(&self, fh: WitFH) -> Result<String, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.readlink(&fh)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn readlink_path(&self, path: String) -> Result<String, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.readlink_path(&path)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn lookup(&self, dir_fh: Vec<u8>, filename: String) -> Result<Vec<u8>, WitError> {
+    fn lookup(&self, dir_fh: WitFH, filename: String) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.lookup(&dir_fh, &filename)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn lookup_path(&self, path: String) -> Result<Vec<u8>, WitError> {
+    fn lookup_path(&self, path: String) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.lookup_path(&path)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn pathconf(&self, fh: Vec<u8>) -> Result<WitPathconf, WitError> {
+    fn pathconf(&self, fh: WitFH) -> Result<WitPathconf, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.pathconf(&fh)
-            .map(into_wit_path_conf)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     fn pathconf_path(&self, path: String) -> Result<WitPathconf, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.pathconf_path(&path)
-            .map(into_wit_path_conf)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn read(&self, fh: Vec<u8>, offset: u64, count: u32) -> Result<Vec<u8>, WitError> {
+    fn read(&self, fh: WitFH, offset: u64, count: u32) -> Result<WitBytes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.read(&fh, offset, count)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn read_path(&self, path: String, offset: u64, count: u32) -> Result<Vec<u8>, WitError> {
+    fn read_path(&self, path: String, offset: u64, count: u32) -> Result<WitBytes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.read_path(&path, offset, count)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn write(&self, fh: Vec<u8>, offset: u64, data: Vec<u8>) -> Result<u32, WitError> {
+    fn write(&self, fh: WitFH, offset: u64, data: WitBytes) -> Result<u32, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.write(&fh, offset, &data)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn write_path(&self, path: String, offset: u64, data: Vec<u8>) -> Result<u32, WitError> {
+    fn write_path(&self, path: String, offset: u64, data: WitBytes) -> Result<u32, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.write_path(&path, offset, &data)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn readdir(&self, dir_fh: Vec<u8>) -> Result<Vec<WitReaddirEntry>, WitError> {
+    fn readdir(&self, dir_fh: WitFH) -> Result<Vec<WitReaddirEntry>, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.readdir(&dir_fh)
-            .map(into_wit_readdir_entries)
-            .map_err(into_wit_err)
+            .map(|entries| entries.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
     }
 
     fn readdir_path(&self, dir_path: String) -> Result<Vec<WitReaddirEntry>, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.readdir_path(&dir_path)
-            .map(into_wit_readdir_entries)
-            .map_err(into_wit_err)
+            .map(|entries| entries.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
     }
 
-    fn readdirplus(&self, dir_fh: Vec<u8>) -> Result<Vec<WitReaddirplusEntry>, WitError> {
+    fn readdirplus(&self, dir_fh: WitFH) -> Result<Vec<WitReaddirplusEntry>, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.readdirplus(&dir_fh)
-            .map(into_wit_readdirplus_entries)
-            .map_err(into_wit_err)
+            .map(|entries| entries.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
     }
 
     fn readdirplus_path(&self, dir_path: String) -> Result<Vec<WitReaddirplusEntry>, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.readdirplus_path(&dir_path)
-            .map(into_wit_readdirplus_entries)
-            .map_err(into_wit_err)
+            .map(|entries| entries.into_iter().map(Into::into).collect())
+            .map_err(Into::into)
     }
 
-    fn mkdir(&self, dir_fh: Vec<u8>, dirname: String, mode: u32) -> Result<Vec<u8>, WitError> {
+    fn mkdir(&self, dir_fh: WitFH, dirname: String, mode: u32) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.mkdir(&dir_fh, &dirname, mode)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn mkdir_path(&self, path: String, mode: u32) -> Result<Vec<u8>, WitError> {
+    fn mkdir_path(&self, path: String, mode: u32) -> Result<WitObjRes, WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.mkdir_path(&path, mode)
-            .map_err(into_wit_err)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
-    fn remove(&self, dir_fh: Vec<u8>, filename: String) -> Result<(), WitError> {
+    fn remove(&self, dir_fh: WitFH, filename: String) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.remove(&dir_fh, &filename)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn remove_path(&self, path: String) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.remove_path(&path)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn rmdir(&self, dir_fh: Vec<u8>, dirname: String) -> Result<(), WitError> {
+    fn rmdir(&self, dir_fh: WitFH, dirname: String) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.rmdir(&dir_fh, &dirname)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn rmdir_path(&self, path: String) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.rmdir_path(&path)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
-    fn rename(&self, from_dir_fh: Vec<u8>, from_filename: String, to_dir_fh: Vec<u8>, to_filename: String) -> Result<(), WitError> {
+    fn rename(&self, from_dir_fh: WitFH, from_filename: String, to_dir_fh: WitFH, to_filename: String) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.rename(&from_dir_fh, &from_filename, &to_dir_fh, &to_filename)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn rename_path(&self, from_path: String, to_path: String) -> Result<(), WitError> {
         let mount = get_mount(self.id)?.read().unwrap();
         mount.rename_path(&from_path, &to_path)
-            .map_err(into_wit_err)
+            .map_err(Into::into)
     }
 
     fn umount(&self) -> Result<(), WitError> {
@@ -476,6 +496,6 @@ impl WitMount for crate::NfsMount {
         if ret.is_ok() {
             remove_mount(self.id);
         }
-        ret.map_err(into_wit_err)
+        ret.map_err(Into::into)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod nfs3;
 mod mount;
 mod shared;
 
-pub use mount::{Mount, Attr, Pathconf, ReaddirEntry, ReaddirplusEntry};
+pub use mount::{Mount, Attr, ObjRes, Pathconf, ReaddirEntry, ReaddirplusEntry};
 pub use shared::Time;
 pub use std::io::Error;
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -25,10 +25,10 @@ pub trait Mount: std::fmt::Debug + Send + Sync {
     fn commit_path(&self, path: &str, offset: u64, count: u32) -> Result<()>;
 
     /// Procedure CREATE creates a regular file.
-    fn create(&self, dir_fh: &Vec<u8>, filename: &str, mode: u32) -> Result<Vec<u8>>;
+    fn create(&self, dir_fh: &Vec<u8>, filename: &str, mode: u32) -> Result<ObjRes>;
 
     /// Same as [`Mount::create`] but instead of taking in directory file handle and filename, takes in a path for which directory file handle is obtained by performing LOOKUP procedure.
-    fn create_path(&self, path: &str, mode: u32) -> Result<Vec<u8>>;
+    fn create_path(&self, path: &str, mode: u32) -> Result<ObjRes>;
 
     /// Purges all of the delegations awaiting recovery for a given client.
     fn delegpurge(&self, clientid: u64) -> Result<()>; // FIXME: validate params + return type
@@ -60,11 +60,11 @@ pub trait Mount: std::fmt::Debug + Send + Sync {
     fn link_path(&self, src_path: &str, dst_path: &str) -> Result<Attr>;
 
     /// Procedure SYMLINK creates a new symbolic link.
-    fn symlink(&self, src_path: &str, dst_dir_fh: &Vec<u8>, dst_filename: &str) -> Result<Vec<u8>>;
+    fn symlink(&self, src_path: &str, dst_dir_fh: &Vec<u8>, dst_filename: &str) -> Result<ObjRes>;
 
     /// Same as [`Mount::symlink`] but instead of taking in a destination directory file handle and destination filename, takes in a  destination path for which
     /// directory file handle is obtained by performing LOOKUP procedure.
-    fn symlink_path(&self, src_path: &str, dst_path: &str) -> Result<Vec<u8>>;
+    fn symlink_path(&self, src_path: &str, dst_path: &str) -> Result<ObjRes>;
 
     /// Procedure READLINK reads the data associated with a symbolic link.
     fn readlink(&self, fh: &Vec<u8>) -> Result<String>;
@@ -72,12 +72,12 @@ pub trait Mount: std::fmt::Debug + Send + Sync {
     /// Same as [`Mount::readlink`] but instead of taking in a file handle, takes in a path for which file handle is obtained by performing LOOKUP procedure.
     fn readlink_path(&self, path: &str) -> Result<String>;
 
-    /// Procedure LOOKUP searches a directory for a specific name and returns the file handle for the corresponding file system object.
-    fn lookup(&self, dir_fh: &Vec<u8>, dirname: &str) -> Result<Vec<u8>>;
+    /// Procedure LOOKUP searches a directory for a specific name and returns the file handle and attributes for the corresponding file system object.
+    fn lookup(&self, dir_fh: &Vec<u8>, dirname: &str) -> Result<ObjRes>;
 
     /// Same as [`Mount::lookup`] but instead of taking in a directory file handle and filename, takes in a path for which directory file handle is obtained by performing LOOKUP procedure
     /// for each directory in the path, in turn.
-    fn lookup_path(&self, path: &str) -> Result<Vec<u8>>;
+    fn lookup_path(&self, path: &str) -> Result<ObjRes>;
 
     /// Procedure PATHCONF retrieves the pathconf information for a file or directory.
     fn pathconf(&self, fh: &Vec<u8>) -> Result<Pathconf>;
@@ -114,10 +114,10 @@ pub trait Mount: std::fmt::Debug + Send + Sync {
     fn readdirplus_path(&self, dir_path: &str) -> Result<Vec<ReaddirplusEntry>>;
 
     /// Procedure MKDIR creates a new subdirectory.
-    fn mkdir(&self, dir_fh: &Vec<u8>, dirname: &str, mode: u32) -> Result<Vec<u8>>;
+    fn mkdir(&self, dir_fh: &Vec<u8>, dirname: &str, mode: u32) -> Result<ObjRes>;
 
     /// Same as [`Mount::mkdir`] but instead of taking in directory file handle and dirname, takes in a path for which directory file handle is obtained by performing LOOKUP procedure.
-    fn mkdir_path(&self, path: &str, mode: u32) -> Result<Vec<u8>>;
+    fn mkdir_path(&self, path: &str, mode: u32) -> Result<ObjRes>;
 
     /// Procedure REMOVE removes (deletes) an entry from a directory.
     fn remove(&self, dir_fh: &Vec<u8>, filename: &str) -> Result<()>;
@@ -158,6 +158,13 @@ pub struct Attr {
     pub atime: Time,
     pub mtime: Time,
     pub ctime: Time,
+}
+
+/// Struct describing an NFS entry response as returned by various operations.
+#[derive(Debug, Default, PartialEq)]
+pub struct ObjRes {
+    pub fh: Vec<u8>,
+    pub attr: Option<Attr>,
 }
 
 /// Struct describing path configuration for an NFS entry as returned by [`Mount::pathconf`] and [`Mount::pathconf_path`].

--- a/src/nfs3/access.rs
+++ b/src/nfs3/access.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn access_path(&self, path: &str, mode: u32) -> Result<u32> {
-        self.access(&self.lookup_path(path)?, mode)
+        self.access(&self.lookup_path(path)?.fh, mode)
     }
 
     pub fn access(&self, fh: &Vec<u8>, mode: u32) -> Result<u32> {

--- a/src/nfs3/commit.rs
+++ b/src/nfs3/commit.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn commit_path(&self, path: &str, offset: u64, count: u32) -> Result<()> {
-        self.commit(&self.lookup_path(path)?, offset, count)
+        self.commit(&self.lookup_path(path)?.fh, offset, count)
     }
 
     pub fn commit(&self, fh: &Vec<u8>, offset: u64, count: u32) -> Result<()> {

--- a/src/nfs3/getattr.rs
+++ b/src/nfs3/getattr.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn getattr_path(&self, path: &str) -> Result<Fattr> {
-        self.getattr(&self.lookup_path(path)?)
+        self.getattr(&self.lookup_path(path)?.fh)
     }
 
     pub(crate) fn getattr(&self, fh: &Vec<u8>) -> Result<Fattr> {

--- a/src/nfs3/link.rs
+++ b/src/nfs3/link.rs
@@ -6,8 +6,8 @@ use crate::nfs3;
 impl Mount {
     pub fn link_path(&self, src_path: &str, dst_path: &str) -> Result<Fattr> {
         let (dst_dir, dst_filename) = split_path(dst_path)?;
-        let src_fh = self.lookup_path(src_path)?;
-        let dst_dir_fh = self.lookup_path(&dst_dir)?;
+        let src_fh = self.lookup_path(src_path)?.fh;
+        let dst_dir_fh = self.lookup_path(&dst_dir)?.fh;
         self.link(&src_fh, &dst_dir_fh, &dst_filename)
     }
 

--- a/src/nfs3/mkdir.rs
+++ b/src/nfs3/mkdir.rs
@@ -1,16 +1,16 @@
 use xdr_codec::Unpack;
-use super::{Mount, Result, Error, ErrorKind, MKDIR3args, sattr3, set_size3, from_post_op_fh3};
-use super::nfs3xdr::{MKDIR3res, diropargs3, filename3, nfs_fh3, set_mode3, set_uid3, set_gid3, set_atime, set_mtime};
+use super::{Mount, Result, Error, ErrorKind, ObjRes, MKDIR3args, sattr3, set_size3, from_post_op_fh3};
+use super::nfs3xdr::{diropargs3, filename3, nfs_fh3, set_atime, set_gid3, set_mode3, set_mtime, set_uid3, MKDIR3res, MKDIR3resok};
 use crate::nfs3;
 
 impl Mount {
-    pub fn mkdir_path(&self, path: &str, mode: u32) -> Result<Vec<u8>> {
+    pub fn mkdir_path(&self, path: &str, mode: u32) -> Result<ObjRes> {
         let (dir, dirname) = nfs3::split_path(path)?;
-        let dir_fh = self.lookup_path(&dir)?;
+        let dir_fh = self.lookup_path(&dir)?.fh;
         self.mkdir(&dir_fh, &dirname, mode)
     }
 
-    pub fn mkdir(&self, dir_fh: &Vec<u8>, dirname: &str, mode: u32) -> Result<Vec<u8>> {
+    pub fn mkdir(&self, dir_fh: &Vec<u8>, dirname: &str, mode: u32) -> Result<ObjRes> {
         let args = MKDIR3args{
             where_: diropargs3{dir: nfs_fh3{data: dir_fh.to_vec()}, name: filename3(dirname.to_string())},
             attrs: sattr3{
@@ -36,8 +36,17 @@ impl Mount {
         }
 
         match x.unwrap().0 {
-            MKDIR3res::NFS3_OK(ok) => from_post_op_fh3(ok.obj),
+            MKDIR3res::NFS3_OK(ok) => ok.into(),
             MKDIR3res::default((e, _)) => Err(Error::new(ErrorKind::Other, e)),
         }
+    }
+}
+
+impl From<MKDIR3resok> for Result<ObjRes> {
+    fn from(value: MKDIR3resok) -> Self {
+        Ok(ObjRes{
+            fh: from_post_op_fh3(value.obj)?,
+            attr: value.obj_attributes.into(),
+        })
     }
 }

--- a/src/nfs3/mknod.rs
+++ b/src/nfs3/mknod.rs
@@ -74,7 +74,7 @@ impl Mount {
 
     fn mknod(&self, path: &str, what: mknoddata3) -> Result<Vec<u8>> {
         let (dir, name) = split_path(path)?;
-        let fh = self.lookup_path(&dir)?;
+        let fh = self.lookup_path(&dir)?.fh;
         let args = MKNOD3args{
             where_: diropargs3{dir: nfs_fh3{data: fh}, name: filename3(name)},
             what,

--- a/src/nfs3/mod.rs
+++ b/src/nfs3/mod.rs
@@ -25,7 +25,7 @@ mod write;
 
 pub(crate) use mount::mount;
 
-use crate::{Auth, Time, Result, Error, ErrorKind, rpc};
+use crate::{Auth, Time, ObjRes, Result, Error, ErrorKind, rpc};
 
 enum MountProc3 {
     Null = 0,
@@ -293,6 +293,35 @@ impl From<nfs3xdr::fattr3> for Fattr {
             atime: Time{seconds: attr.atime.seconds, nseconds: attr.atime.nseconds},
             mtime: Time{seconds: attr.mtime.seconds, nseconds: attr.mtime.nseconds},
             ctime: Time{seconds: attr.ctime.seconds, nseconds: attr.ctime.nseconds},
+        }
+    }
+}
+
+impl From<nfs3xdr::fattr3> for crate::mount::Attr {
+    fn from(attr: nfs3xdr::fattr3) -> Self {
+        Self{
+            type_: attr.type_ as u32,
+            file_mode: attr.mode,
+            nlink: attr.nlink,
+            uid: attr.uid,
+            gid: attr.gid,
+            filesize: attr.size,
+            used: attr.used,
+            spec_data: [attr.rdev.specdata1, attr.rdev.specdata2],
+            fsid: attr.fsid,
+            fileid: attr.fileid,
+            atime: Time{seconds: attr.atime.seconds, nseconds: attr.atime.nseconds},
+            mtime: Time{seconds: attr.mtime.seconds, nseconds: attr.mtime.nseconds},
+            ctime: Time{seconds: attr.ctime.seconds, nseconds: attr.ctime.nseconds},
+        }
+    }
+}
+
+impl From<nfs3xdr::post_op_attr> for Option<crate::mount::Attr> {
+    fn from(attr: nfs3xdr::post_op_attr) -> Self {
+        match attr {
+            nfs3xdr::post_op_attr::TRUE(a) => Some(a.into()),
+            nfs3xdr::post_op_attr::FALSE => None,
         }
     }
 }

--- a/src/nfs3/mount.rs
+++ b/src/nfs3/mount.rs
@@ -2,7 +2,7 @@
 use std::io;
 
 use xdr_codec::{Pack, Unpack};
-use super::{Mount, Error, ErrorKind, Result, MOUNT3args, Time};
+use super::{Mount, Error, ErrorKind, Result, MOUNT3args, Time, ObjRes};
 use super::mount3xdr::{dirpath, mountres3};
 use crate::{SocketAddr, TcpStream, ToSocketAddrs, nfs3, rpc};
 
@@ -59,11 +59,11 @@ impl crate::Mount for Mount3 {
         self.m.commit_path(path, offset, count)
     }
 
-    fn create(&self, dir_fh: &Vec<u8>, filename: &str, mode: u32) -> Result<Vec<u8>> {
+    fn create(&self, dir_fh: &Vec<u8>, filename: &str, mode: u32) -> Result<ObjRes> {
         self.m.create(dir_fh, filename, mode)
     }
 
-    fn create_path(&self, path: &str, mode: u32) -> Result<Vec<u8>> {
+    fn create_path(&self, path: &str, mode: u32) -> Result<ObjRes> {
         self.m.create_path(path, mode)
     }
 
@@ -103,11 +103,11 @@ impl crate::Mount for Mount3 {
         self.m.link_path(src_path, dst_path).map(|res| res.into())
     }
 
-    fn symlink(&self, src_path: &str, dst_dir_fh: &Vec<u8>, dst_filename: &str) -> Result<Vec<u8>> {
+    fn symlink(&self, src_path: &str, dst_dir_fh: &Vec<u8>, dst_filename: &str) -> Result<ObjRes> {
         self.m.symlink(src_path, dst_dir_fh, dst_filename)
     }
 
-    fn symlink_path(&self, src_path: &str, dst_path: &str) -> Result<Vec<u8>> {
+    fn symlink_path(&self, src_path: &str, dst_path: &str) -> Result<ObjRes> {
         self.m.symlink_path(src_path, dst_path)
     }
 
@@ -119,11 +119,11 @@ impl crate::Mount for Mount3 {
         self.m.readlink_path(path)
     }
 
-    fn lookup(&self, dir_fh: &Vec<u8>, filename: &str) -> Result<Vec<u8>> {
+    fn lookup(&self, dir_fh: &Vec<u8>, filename: &str) -> Result<ObjRes> {
         self.m.lookup(dir_fh, filename)
     }
 
-    fn lookup_path(&self, path: &str) -> Result<Vec<u8>> {
+    fn lookup_path(&self, path: &str) -> Result<ObjRes> {
         self.m.lookup_path(path)
     }
 
@@ -167,11 +167,11 @@ impl crate::Mount for Mount3 {
         Ok(self.m.readdirplus_path(dir_path)?.iter().map(|e| e.into()).collect())
     }
 
-    fn mkdir(&self, dir_fh: &Vec<u8>, dirname: &str, mode: u32) -> Result<Vec<u8>> {
+    fn mkdir(&self, dir_fh: &Vec<u8>, dirname: &str, mode: u32) -> Result<ObjRes> {
         self.m.mkdir(dir_fh, dirname, mode)
     }
 
-    fn mkdir_path(&self, path: &str, mode: u32) -> Result<Vec<u8>> {
+    fn mkdir_path(&self, path: &str, mode: u32) -> Result<ObjRes> {
         self.m.mkdir_path(path, mode)
     }
 

--- a/src/nfs3/pathconf.rs
+++ b/src/nfs3/pathconf.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn pathconf_path(&self, path: &str) -> Result<Pathconf> {
-        self.pathconf(&self.lookup_path(path)?)
+        self.pathconf(&self.lookup_path(path)?.fh)
     }
 
     pub fn pathconf(&self, fh: &Vec<u8>) -> Result<Pathconf> {

--- a/src/nfs3/read.rs
+++ b/src/nfs3/read.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn read_path(&self, path: &str, offset: u64, count: u32) -> Result<Vec<u8>> {
-        self.read(&self.lookup_path(path)?, offset, count)
+        self.read(&self.lookup_path(path)?.fh, offset, count)
     }
 
     pub fn read(&self, fh: &Vec<u8>, offset: u64, count: u32) -> Result<Vec<u8>> {

--- a/src/nfs3/readdir.rs
+++ b/src/nfs3/readdir.rs
@@ -22,7 +22,7 @@ impl From<&ReaddirEntry> for crate::mount::ReaddirEntry {
 
 impl Mount {
     pub fn readdir_path(&self, dir_path: &str) -> Result<Vec<ReaddirEntry>> {
-        self.readdir(&self.lookup_path(dir_path)?)
+        self.readdir(&self.lookup_path(dir_path)?.fh)
     }
 
     pub fn readdir(&self, dir_fh: &Vec<u8>) -> Result<Vec<ReaddirEntry>> {

--- a/src/nfs3/readdirplus.rs
+++ b/src/nfs3/readdirplus.rs
@@ -26,7 +26,7 @@ impl From<&ReaddirplusEntry> for crate::mount::ReaddirplusEntry {
 
 impl Mount {
     pub fn readdirplus_path(&self, dir_path: &str) -> Result<Vec<ReaddirplusEntry>> {
-        self.readdirplus(&self.lookup_path(dir_path)?)
+        self.readdirplus(&self.lookup_path(dir_path)?.fh)
     }
 
     pub fn readdirplus(&self, dir_fh: &Vec<u8>) -> Result<Vec<ReaddirplusEntry>> {

--- a/src/nfs3/readlink.rs
+++ b/src/nfs3/readlink.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn readlink_path(&self, path: &str) -> Result<String> {
-        self.readlink(&self.lookup_path(path)?)
+        self.readlink(&self.lookup_path(path)?.fh)
     }
 
     pub fn readlink(&self, fh: &Vec<u8>) -> Result<String> {

--- a/src/nfs3/remove.rs
+++ b/src/nfs3/remove.rs
@@ -6,7 +6,7 @@ use crate::nfs3;
 impl Mount {
     pub fn remove_path(&self, path: &str) -> Result<()> {
         let (dir, filename) = nfs3::split_path(path)?;
-        let dir_fh = self.lookup_path(&dir)?;
+        let dir_fh = self.lookup_path(&dir)?.fh;
         self.remove(&dir_fh, &filename)
     }
 

--- a/src/nfs3/rename.rs
+++ b/src/nfs3/rename.rs
@@ -8,11 +8,11 @@ impl Mount {
         let (from_dir, from_filename) = split_path(from)?;
         let (to_dir, to_filename) = split_path(to)?;
         let is_same_dir = from_dir == to_dir;
-        let from_dir_fh = self.lookup_path(&from_dir)?;
+        let from_dir_fh = self.lookup_path(&from_dir)?.fh;
         let to_dir_fh = if is_same_dir {
             from_dir_fh.to_vec()
         } else {
-            self.lookup_path(&to_dir)?
+            self.lookup_path(&to_dir)?.fh
         };
         self.rename(&from_dir_fh, &from_filename, &to_dir_fh, &to_filename)
     }

--- a/src/nfs3/rmdir.rs
+++ b/src/nfs3/rmdir.rs
@@ -6,7 +6,7 @@ use crate::nfs3;
 impl Mount {
     pub fn rmdir_path(&self, path: &str) -> Result<()> {
         let (dir, dirname) = nfs3::split_path(path)?;
-        let dir_fh = self.lookup_path(&dir)?;
+        let dir_fh = self.lookup_path(&dir)?.fh;
         self.rmdir(&dir_fh, &dirname)
     }
 

--- a/src/nfs3/setattr.rs
+++ b/src/nfs3/setattr.rs
@@ -1,16 +1,16 @@
 use xdr_codec::Unpack;
 use super::{Mount, Result, Error, ErrorKind, Time, SETATTR3args, sattr3, set_size3};
-use super::nfs3xdr::{SETATTR3res, nfstime3, nfs_fh3, post_op_attr, sattrguard3, set_mode3, set_uid3, set_gid3, set_atime, set_mtime};
+use super::nfs3xdr::{SETATTR3res, nfstime3, nfs_fh3, sattrguard3, set_mode3, set_uid3, set_gid3, set_atime, set_mtime};
 use crate::nfs3;
 
 impl Mount {
     pub fn setattr_path(&self, path: &str, specify_guard: bool, mode: Option<u32>, uid: Option<u32>, gid: Option<u32>, size: Option<u64>, atime: Option<Time>, mtime: Option<Time>) -> Result<()> {
-        let res = self.lookup_path_raw(path)?;
-        let guard_ctime = match (specify_guard, res.obj_attributes) {
-            (true, post_op_attr::TRUE(ok)) => Some(Time{seconds: ok.ctime.seconds, nseconds: ok.ctime.nseconds}),
+        let res = self.lookup_path(path)?;
+        let guard_ctime = match (specify_guard, res.attr) {
+            (true, Some(attr)) => Some(Time{seconds: attr.ctime.seconds, nseconds: attr.ctime.nseconds}),
             _ => None,
         };
-        self.setattr(&res.object.data, guard_ctime, mode, uid, gid, size, atime, mtime)
+        self.setattr(&res.fh, guard_ctime, mode, uid, gid, size, atime, mtime)
     }
 
     pub fn setattr(&self, fh: &Vec<u8>, guard_ctime: Option<Time>, mode: Option<u32>, uid: Option<u32>, gid: Option<u32>, size: Option<u64>, atime: Option<Time>, mtime: Option<Time>) -> Result<()> {

--- a/src/nfs3/symlink.rs
+++ b/src/nfs3/symlink.rs
@@ -1,16 +1,16 @@
 use xdr_codec::Unpack;
-use super::{Mount, Result, Error, ErrorKind, SYMLINK3args, sattr3, symlinkdata3, from_post_op_fh3, split_path};
-use super::nfs3xdr::{SYMLINK3res, diropargs3, filename3, nfs_fh3, nfspath3};
+use super::{Mount, Result, Error, ErrorKind, ObjRes, SYMLINK3args, sattr3, symlinkdata3, from_post_op_fh3, split_path};
+use super::nfs3xdr::{diropargs3, filename3, nfs_fh3, nfspath3, SYMLINK3res, SYMLINK3resok};
 use crate::nfs3;
 
 impl Mount {
-    pub fn symlink_path(&self, src_path: &str, dst_path: &str) -> Result<Vec<u8>> {
+    pub fn symlink_path(&self, src_path: &str, dst_path: &str) -> Result<ObjRes> {
         let (dst_dir, dst_filename) = split_path(dst_path)?;
-        let dst_dir_fh = self.lookup_path(&dst_dir)?;
+        let dst_dir_fh = self.lookup_path(&dst_dir)?.fh;
         self.symlink(src_path, &dst_dir_fh, &dst_filename)
     }
 
-    pub fn symlink(&self, src_path: &str, dst_dir_fh: &Vec<u8>, dst_filename: &str) -> Result<Vec<u8>> {
+    pub fn symlink(&self, src_path: &str, dst_dir_fh: &Vec<u8>, dst_filename: &str) -> Result<ObjRes> {
         let args = SYMLINK3args{
             where_: diropargs3{dir: nfs_fh3{data: dst_dir_fh.to_vec()}, name: filename3(dst_filename.to_string())},
             symlink: symlinkdata3{symlink_attributes: sattr3::default(), symlink_data: nfspath3(src_path.to_string())},
@@ -29,8 +29,17 @@ impl Mount {
         }
 
         match x.unwrap().0 {
-            SYMLINK3res::NFS3_OK(ok) => from_post_op_fh3(ok.obj),
+            SYMLINK3res::NFS3_OK(ok) => ok.into(),
             SYMLINK3res::default((e, _)) => Err(Error::new(ErrorKind::Other, e)),
         }
+    }
+}
+
+impl From<SYMLINK3resok> for Result<ObjRes> {
+    fn from(value: SYMLINK3resok) -> Self {
+        Ok(ObjRes{
+            fh: from_post_op_fh3(value.obj)?,
+            attr: value.obj_attributes.into(),
+        })
     }
 }

--- a/src/nfs3/write.rs
+++ b/src/nfs3/write.rs
@@ -5,7 +5,7 @@ use crate::nfs3;
 
 impl Mount {
     pub fn write_path(&self, path: &str, offset: u64, data: &Vec<u8>) -> Result<u32> {
-        self.write(&self.lookup_path(path)?, offset, data)
+        self.write(&self.lookup_path(path)?.fh, offset, data)
     }
 
     pub fn write(&self, fh: &Vec<u8>, offset: u64, data: &Vec<u8>) -> Result<u32> {

--- a/wit/nfs.wit
+++ b/wit/nfs.wit
@@ -1,4 +1,7 @@
 interface nfs {
+    type fh = list<u8>;
+    type bytes = list<u8>;
+
     record time {
         seconds: u32,
         nseconds: u32,
@@ -18,6 +21,11 @@ interface nfs {
         atime: time,
         mtime: time,
         ctime: time,
+    }
+
+    record obj-res {
+        obj: fh,
+        attr: option<attr>,
     }
 
     record path-conf {
@@ -41,7 +49,7 @@ interface nfs {
         file-name: string,
         cookie: u64,
         attr: option<attr>,
-        handle: list<u8>,
+        handle: fh,
     }
 
     record error {
@@ -53,45 +61,45 @@ interface nfs {
 
     resource nfs-mount {
         null-op: func() -> result<_, error>;
-        access: func(fh: list<u8>, mode: u32) -> result<u32, error>;
+        access: func(fh: fh, mode: u32) -> result<u32, error>;
         access-path: func(path: string, mode: u32) -> result<u32, error>;
         close: func(seqid: u32, stateid: u64) -> result<_, error>;
-        commit: func(fh: list<u8>, offset: u64, count: u32) -> result<_, error>;
+        commit: func(fh: fh, offset: u64, count: u32) -> result<_, error>;
         commit-path: func(path: string, offset: u64, count: u32) -> result<_, error>;
-        create: func(dir-fh: list<u8>, filename: string, mode: u32) -> result<list<u8>, error>;
-        create-path: func(path: string, mode: u32) -> result<list<u8>, error>;
+        create: func(dir-fh: fh, filename: string, mode: u32) -> result<obj-res, error>;
+        create-path: func(path: string, mode: u32) -> result<obj-res, error>;
         delegpurge: func(clientid: u64) -> result<_, error>;
         delegreturn: func(stateid: u64) -> result<_, error>;
-        getattr: func(fh: list<u8>) -> result<attr, error>;
+        getattr: func(fh: fh) -> result<attr, error>;
         getattr-path: func(path: string) -> result<attr, error>;
-        setattr: func(fh: list<u8>, guard-ctime: option<time>, mode: option<u32>, uid: option<u32>, gid: option<u32>, size: option<u64>, atime: option<time>, mtime: option<time>) -> result<_, error>;
+        setattr: func(fh: fh, guard-ctime: option<time>, mode: option<u32>, uid: option<u32>, gid: option<u32>, size: option<u64>, atime: option<time>, mtime: option<time>) -> result<_, error>;
         setattr-path: func(path: string, specify-guard: bool, mode: option<u32>, uid: option<u32>, gid: option<u32>, size: option<u64>, atime: option<time>, mtime: option<time>) -> result<_, error>;
         getfh: func() -> result<_, error>;
-        link: func(src-fh: list<u8>, dst-dir-fh: list<u8>, dst-filename: string) -> result<attr, error>;
+        link: func(src-fh: fh, dst-dir-fh: fh, dst-filename: string) -> result<attr, error>;
         link-path: func(src-path: string, dst-path: string) -> result<attr, error>;
-        symlink: func(src-path: string, dst-dir-fh: list<u8>, dst-filename: string) -> result<list<u8>, error>;
-        symlink-path: func(src-path: string, dst-path: string) -> result<list<u8>, error>;
-        readlink: func(fh: list<u8>) -> result<string, error>;
+        symlink: func(src-path: string, dst-dir-fh: fh, dst-filename: string) -> result<obj-res, error>;
+        symlink-path: func(src-path: string, dst-path: string) -> result<obj-res, error>;
+        readlink: func(fh: fh) -> result<string, error>;
         readlink-path: func(path: string) -> result<string, error>;
-        lookup: func(dir-fh: list<u8>, filename: string) -> result<list<u8>, error>;
-        lookup-path: func(path: string) -> result<list<u8>, error>;
-        pathconf: func(fh: list<u8>) -> result<path-conf, error>;
+        lookup: func(dir-fh: fh, filename: string) -> result<obj-res, error>;
+        lookup-path: func(path: string) -> result<obj-res, error>;
+        pathconf: func(fh: fh) -> result<path-conf, error>;
         pathconf-path: func(path: string) -> result<path-conf, error>;
-        read: func(fh: list<u8>, offset: u64, count: u32) -> result<list<u8>, error>;
-        read-path: func(path: string, offset: u64, count: u32) -> result<list<u8>, error>;
-        write: func(fh: list<u8>, offset: u64, data: list<u8>) -> result<u32, error>;
-        write-path: func(path: string, offset: u64, data: list<u8>) -> result<u32, error>;
-        readdir: func(dir-fh: list<u8>) -> result<list<readdir-entry>, error>;
+        read: func(fh: fh, offset: u64, count: u32) -> result<bytes, error>;
+        read-path: func(path: string, offset: u64, count: u32) -> result<bytes, error>;
+        write: func(fh: fh, offset: u64, data: bytes) -> result<u32, error>;
+        write-path: func(path: string, offset: u64, data: bytes) -> result<u32, error>;
+        readdir: func(dir-fh: fh) -> result<list<readdir-entry>, error>;
         readdir-path: func(dir-path: string) -> result<list<readdir-entry>, error>;
-        readdirplus: func(dir-fh: list<u8>) -> result<list<readdirplus-entry>, error>;
+        readdirplus: func(dir-fh: fh) -> result<list<readdirplus-entry>, error>;
         readdirplus-path: func(dir-path: string) -> result<list<readdirplus-entry>, error>;
-        mkdir: func(dir-fh: list<u8>, dirname: string, mode: u32) -> result<list<u8>, error>;
-        mkdir-path: func(path: string, mode: u32) -> result<list<u8>, error>;
-        remove: func(dir-fh: list<u8>, filename: string) -> result<_, error>;
+        mkdir: func(dir-fh: fh, dirname: string, mode: u32) -> result<obj-res, error>;
+        mkdir-path: func(path: string, mode: u32) -> result<obj-res, error>;
+        remove: func(dir-fh: fh, filename: string) -> result<_, error>;
         remove-path: func(path: string) -> result<_, error>;
-        rmdir: func(dir-fh: list<u8>, dirname: string) -> result<_, error>;
+        rmdir: func(dir-fh: fh, dirname: string) -> result<_, error>;
         rmdir-path: func(path: string) -> result<_, error>;
-        rename: func(from-dir-fh: list<u8>, from-filename: string, to-dir-fh: list<u8>, to-filename: string) -> result<_, error>;
+        rename: func(from-dir-fh: fh, from-filename: string, to-dir-fh: fh, to-filename: string) -> result<_, error>;
         rename-path: func(from-path: string, to-path: string) -> result<_, error>;
         umount: func() -> result<_, error>;
     }


### PR DESCRIPTION
For NFS operations, whose response includes both a file handle and attributes, changed exported function to return both (instead of just returning file handle). Replaced list<u8> with properly named aliases for file handle and bytes in wit.